### PR TITLE
feat: add language switcher to entry page

### DIFF
--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -33,13 +33,14 @@ function getBrowserLocale(): LocaleCode {
   return "en";
 }
 
-// Get saved locale from localStorage or use browser default
+// Get saved locale from localStorage or use English as default
 function getSavedLocale(): LocaleCode {
   const saved = localStorage.getItem("locale") as LocaleCode | null;
   if (saved && dictionaries[saved]) {
     return saved;
   }
-  return getBrowserLocale();
+  // Default to English instead of browser language
+  return "en";
 }
 
 // Save locale to localStorage

--- a/src/pages/EntryPage.tsx
+++ b/src/pages/EntryPage.tsx
@@ -287,9 +287,12 @@ export default function EntryPage() {
 
   return (
     <div class="flex flex-col min-h-screen bg-gray-50/50 dark:bg-zinc-950 font-sans text-gray-900 dark:text-gray-100">
-      <div class="absolute top-4 right-4">
-        <LanguageSwitcher />
-      </div>
+      {/* Language switcher for remote login page (non-local mode) */}
+      <Show when={!isLocal()}>
+        <div class="absolute top-4 right-4 z-20">
+          <LanguageSwitcher />
+        </div>
+      </Show>
 
       {/* Loading state */}
       <Show when={checking()}>
@@ -450,8 +453,11 @@ export default function EntryPage() {
             <div class="flex items-center gap-2">
               <h1 class="font-semibold text-lg">{t().remote.title}</h1>
             </div>
-            <div class="text-xs font-medium px-2 py-1 rounded bg-gray-100 dark:bg-zinc-800 text-gray-500 dark:text-gray-400">
-              OpenCode Remote
+            <div class="flex items-center gap-3">
+              <LanguageSwitcher />
+              <div class="text-xs font-medium px-2 py-1 rounded bg-gray-100 dark:bg-zinc-800 text-gray-500 dark:text-gray-400">
+                OpenCode Remote
+              </div>
             </div>
           </header>
 


### PR DESCRIPTION
Summary
- Add language switcher to the entry page for both local (host) and remote access modes
- Default language is now English instead of browser language detection
- Remote login page: language switcher appears in top-right corner
- Local mode (host): language switcher appears in the header next to "OpenCode Remote" badge
 Changes
- `src/lib/i18n.tsx`: Modified `getSavedLocale()` to default to English
- `src/pages/EntryPage.tsx`: Added language switcher for both local and remote modes