### PR TITLE
fix: stop timer ticking on inactive sessions without completed timestamp

### DIFF
--- a/src/components/SessionTurn.tsx
+++ b/src/components/SessionTurn.tsx
@@ -577,7 +577,7 @@ export function SessionTurn(props: SessionTurnProps) {
     // tasks, intermediate messages may carry completed timestamps prematurely.
     if (props.isWorking) return undefined;
     const lastAssistant = props.assistantMessages.at(-1);
-    return lastAssistant?.time?.completed;
+    return lastAssistant?.time?.completed ?? lastAssistant?.time?.created;
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

Fix timer on inactive sessions: when switching to a chat with completed AI responses, the elapsed time counter was incorrectly ticking instead of showing a static value.

## Changes

- Fix `finalEndTime` memo in SessionTurn.tsx to fall back to the last assistant message's `time.created` when `time.completed` is absent — prevents `setInterval` from running on already-finished sessions

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->

## Test Plan

- [x] Manual testing (describe steps below)
- [x] Unit tests pass (`bun run test:unit`)
- [x] E2E tests pass (`bun run test:e2e`)
- [x] Type check passes (`npm run typecheck`)

**Manual steps:**
1. Start a chat session and send a message, wait for the AI to finish responding
2. Switch to another session and back
3. Verify that the elapsed time on the completed message is static and not ticking
