### PR TITLE
feat(auth): auto-cleanup inactive devices after 14 days

### DIFF
--- a/shared/device-store-base.ts
+++ b/shared/device-store-base.ts
@@ -16,6 +16,9 @@ const REQUEST_EXPIRY_MS = 5 * 60 * 1000;
 /** Resolved requests are cleaned up after 24 hours */
 const RESOLVED_RETENTION_MS = 24 * 60 * 60 * 1000;
 
+/** Non-host devices inactive for 14 days are automatically removed */
+const DEVICE_INACTIVE_MS = 14 * 24 * 60 * 60 * 1000;
+
 // =============================================================================
 // DeviceStoreBase — abstract base class
 // =============================================================================
@@ -153,6 +156,7 @@ export abstract class DeviceStoreBase {
   /** Returns devices sorted by lastSeenAt descending (most recently active first). */
   listDevices(): DeviceInfo[] {
     this.beforeRead();
+    this.cleanupInactiveDevices();
     return Object.values(this.getData().devices).sort(
       (a, b) => b.lastSeenAt - a.lastSeenAt,
     );
@@ -379,7 +383,7 @@ export abstract class DeviceStoreBase {
     }
   }
 
-  private cleanupExpiredRequests(): void {
+  protected cleanupExpiredRequests(): void {
     const data = this.getData();
     let changed = false;
 
@@ -401,6 +405,30 @@ export abstract class DeviceStoreBase {
         request.resolvedAt < cutoff
       ) {
         delete data.pendingRequests[id];
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      this.save();
+    }
+
+    // Also clean up inactive devices
+    this.cleanupInactiveDevices();
+  }
+
+  /**
+   * Remove non-host devices that have been inactive for longer than DEVICE_INACTIVE_MS.
+   * Host devices (isHost: true) are never auto-removed.
+   */
+  protected cleanupInactiveDevices(): void {
+    const data = this.getData();
+    const cutoff = Date.now() - DEVICE_INACTIVE_MS;
+    let changed = false;
+
+    for (const [id, device] of Object.entries(data.devices)) {
+      if (!device.isHost && device.lastSeenAt < cutoff) {
+        delete data.devices[id];
         changed = true;
       }
     }

--- a/shared/device-store-base.ts
+++ b/shared/device-store-base.ts
@@ -36,6 +36,12 @@ const DEVICE_INACTIVE_MS = 14 * 24 * 60 * 60 * 1000;
 export abstract class DeviceStoreBase {
   protected data: DeviceStoreData | null = null;
 
+  /** Timestamp of last inactive-device cleanup run (throttle guard). */
+  private lastCleanupAt = 0;
+
+  /** Minimum interval between inactive-device cleanup runs (1 hour). */
+  private static CLEANUP_THROTTLE_MS = 60 * 60 * 1000;
+
   /** Subclass provides the absolute path to the devices JSON file. */
   protected abstract getFilePath(): string;
 
@@ -149,6 +155,7 @@ export abstract class DeviceStoreBase {
     if (data.devices[deviceId]) {
       data.devices[deviceId].lastSeenAt = Date.now();
       data.devices[deviceId].ip = ip;
+      this.cleanupInactiveDevicesThrottled();
       this.save();
     }
   }
@@ -184,7 +191,6 @@ export abstract class DeviceStoreBase {
 
   verifyToken(token: string): { valid: boolean; deviceId?: string } {
     this.beforeRead();
-    this.cleanupInactiveDevices();
 
     const data = this.getData();
     const result = verifyJWT(token, data.jwtSecret);
@@ -194,6 +200,13 @@ export abstract class DeviceStoreBase {
 
     const device = data.devices[result.payload.deviceId];
     if (!device) {
+      return { valid: false };
+    }
+
+    // Reject inactive non-host devices without deleting them.
+    // Actual cleanup happens lazily via updateLastSeen / listDevices.
+    const cutoff = Date.now() - DEVICE_INACTIVE_MS;
+    if (!device.isHost && device.lastSeenAt < cutoff) {
       return { valid: false };
     }
 
@@ -415,6 +428,17 @@ export abstract class DeviceStoreBase {
     }
 
     // Also clean up inactive devices
+    this.cleanupInactiveDevices();
+  }
+
+  /**
+   * Throttled wrapper: only runs cleanupInactiveDevices if at least
+   * CLEANUP_THROTTLE_MS has elapsed since the last run.
+   */
+  private cleanupInactiveDevicesThrottled(): void {
+    const now = Date.now();
+    if (now - this.lastCleanupAt < DeviceStoreBase.CLEANUP_THROTTLE_MS) return;
+    this.lastCleanupAt = now;
     this.cleanupInactiveDevices();
   }
 

--- a/shared/device-store-base.ts
+++ b/shared/device-store-base.ts
@@ -184,6 +184,7 @@ export abstract class DeviceStoreBase {
 
   verifyToken(token: string): { valid: boolean; deviceId?: string } {
     this.beforeRead();
+    this.cleanupInactiveDevices();
 
     const data = this.getData();
     const result = verifyJWT(token, data.jwtSecret);
@@ -420,15 +421,34 @@ export abstract class DeviceStoreBase {
   /**
    * Remove non-host devices that have been inactive for longer than DEVICE_INACTIVE_MS.
    * Host devices (isHost: true) are never auto-removed.
+   *
+   * Re-reads the store before saving to reduce the lost-update window in dev mode,
+   * where the file may be shared with another process.
    */
   protected cleanupInactiveDevices(): void {
     const data = this.getData();
     const cutoff = Date.now() - DEVICE_INACTIVE_MS;
-    let changed = false;
 
+    const inactiveIds: string[] = [];
     for (const [id, device] of Object.entries(data.devices)) {
       if (!device.isHost && device.lastSeenAt < cutoff) {
-        delete data.devices[id];
+        inactiveIds.push(id);
+      }
+    }
+
+    if (inactiveIds.length === 0) {
+      return;
+    }
+
+    // Reload before saving to avoid overwriting concurrent changes in dev mode.
+    this.beforeRead();
+    const freshData = this.getData();
+    let changed = false;
+
+    for (const id of inactiveIds) {
+      const device = freshData.devices[id];
+      if (device && !device.isHost && device.lastSeenAt < cutoff) {
+        delete freshData.devices[id];
         changed = true;
       }
     }

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -300,6 +300,7 @@ export interface LocaleDict {
     revokeOthersSuccess: string;
     noOtherDevices: string;
     securityTip: string;
+    inactiveCleanupTip: string;
     justNow: string;
     minutesAgo: string;
     hoursAgo: string;
@@ -905,6 +906,7 @@ export const en: LocaleDict = {
     revokeOthersSuccess: "{count} device(s) revoked",
     noOtherDevices: "No other authorized devices",
     securityTip: "If you see an unfamiliar device, revoke its access immediately",
+    inactiveCleanupTip: "Devices inactive for more than 14 days are automatically removed and will need to re-authorize",
     justNow: "just now",
     minutesAgo: "{count} min ago",
     hoursAgo: "{count}h ago",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -301,6 +301,7 @@ export const ru: LocaleDict = {
     revokeOthersSuccess: "Отозвано устройств: {count}",
     noOtherDevices: "Нет других авторизованных устройств",
     securityTip: "Если вы видите незнакомое устройство, немедленно отзовите его доступ",
+    inactiveCleanupTip: "Устройства, неактивные более 14 дней, автоматически удаляются и потребуют повторной авторизации",
     justNow: "Только что",
     minutesAgo: "{count} мин. назад",
     hoursAgo: "{count} ч. назад",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -300,6 +300,7 @@ export const zh: LocaleDict = {
     revokeOthersSuccess: "已撤销 {count} 个设备",
     noOtherDevices: "没有其他已授权的设备",
     securityTip: "如果发现不认识的设备，请立即撤销其访问权限",
+    inactiveCleanupTip: "超过 14 天未活跃的设备将被自动移除，需要重新授权",
     justNow: "刚刚",
     minutesAgo: "{count}分钟前",
     hoursAgo: "{count}小时前",

--- a/src/pages/Devices.tsx
+++ b/src/pages/Devices.tsx
@@ -337,6 +337,18 @@ export default function Devices() {
                 {t().devices.securityTip}
               </p>
             </div>
+
+            {/* Inactive Cleanup Info */}
+            <div class="rounded-xl bg-blue-50 dark:bg-blue-900/10 border border-blue-100 dark:border-blue-900/30 p-4 flex gap-3">
+              <svg xmlns="http://www.w3.org/2000/svg" class="shrink-0 text-blue-600 dark:text-blue-400 mt-0.5" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/>
+                <path d="M12 16v-4"/>
+                <path d="M12 8h.01"/>
+              </svg>
+              <p class="text-sm text-blue-800 dark:text-blue-200">
+                {t().devices.inactiveCleanupTip}
+              </p>
+            </div>
           </Show>
         </div>
       </main>

--- a/tests/unit/shared/device-store-base.test.ts
+++ b/tests/unit/shared/device-store-base.test.ts
@@ -291,7 +291,7 @@ describe('DeviceStoreBase', () => {
       expect(store.getDevice('stale')).toBeUndefined();
     });
 
-    it('invalidates tokens for cleaned-up devices via verifyToken', () => {
+    it('rejects tokens for inactive devices via verifyToken without deleting them', () => {
       vi.useFakeTimers();
       const now = Date.now();
 
@@ -302,7 +302,43 @@ describe('DeviceStoreBase', () => {
       // Simulate 15 days of inactivity
       vi.advanceTimersByTime(FOURTEEN_DAYS + 1);
       expect(store.verifyToken(token).valid).toBe(false);
-      expect(store.getDevice('d1')).toBeUndefined();
+      // Device is still in store — verifyToken does not delete, only rejects
+      expect(store.getDevice('d1')).toBeDefined();
+    });
+
+    it('triggers cleanup via updateLastSeen', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'stale', lastSeenAt: now - FOURTEEN_DAYS - 1 } as any);
+      store.addDevice({ id: 'active', lastSeenAt: now } as any);
+
+      store.updateLastSeen('active', '1.2.3.4');
+
+      expect(store.getDevice('stale')).toBeUndefined();
+      expect(store.getDevice('active')).toBeDefined();
+    });
+
+    it('throttles cleanup in updateLastSeen to avoid redundant runs', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'active', lastSeenAt: now } as any);
+
+      // First updateLastSeen triggers cleanup
+      store.updateLastSeen('active', '1.1.1.1');
+
+      // Add a stale device after cleanup already ran
+      store.addDevice({ id: 'stale', lastSeenAt: now - FOURTEEN_DAYS - 1 } as any);
+
+      // Second call within throttle window — cleanup is skipped
+      store.updateLastSeen('active', '2.2.2.2');
+      expect(store.getDevice('stale')).toBeDefined();
+
+      // Advance past throttle interval (1 hour)
+      vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+      store.updateLastSeen('active', '3.3.3.3');
+      expect(store.getDevice('stale')).toBeUndefined();
     });
   });
 

--- a/tests/unit/shared/device-store-base.test.ts
+++ b/tests/unit/shared/device-store-base.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { DeviceStoreBase } from '../../../shared/device-store-base';
 import fs from 'fs';
 
@@ -239,6 +239,10 @@ describe('DeviceStoreBase', () => {
   describe('Inactive Device Auto-Cleanup', () => {
     const FOURTEEN_DAYS = 14 * 24 * 60 * 60 * 1000;
 
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('removes non-host devices inactive for more than 14 days', () => {
       vi.useFakeTimers();
       const now = Date.now();
@@ -250,7 +254,6 @@ describe('DeviceStoreBase', () => {
 
       expect(store.getDevice('d1')).toBeUndefined();
       expect(store.getDevice('d2')).toBeDefined();
-      vi.useRealTimers();
     });
 
     it('never removes host devices regardless of inactivity', () => {
@@ -264,7 +267,6 @@ describe('DeviceStoreBase', () => {
 
       expect(store.getDevice('host')).toBeDefined();
       expect(store.getDevice('remote')).toBeUndefined();
-      vi.useRealTimers();
     });
 
     it('triggers cleanup when listing devices', () => {
@@ -277,7 +279,6 @@ describe('DeviceStoreBase', () => {
       const devices = store.listDevices();
       expect(devices).toHaveLength(1);
       expect(devices[0].id).toBe('active');
-      vi.useRealTimers();
     });
 
     it('triggers cleanup via cleanupExpiredRequests', () => {
@@ -288,10 +289,9 @@ describe('DeviceStoreBase', () => {
       store.cleanupExpiredRequestsPublic();
 
       expect(store.getDevice('stale')).toBeUndefined();
-      vi.useRealTimers();
     });
 
-    it('invalidates tokens for cleaned-up devices', () => {
+    it('invalidates tokens for cleaned-up devices via verifyToken', () => {
       vi.useFakeTimers();
       const now = Date.now();
 
@@ -301,10 +301,8 @@ describe('DeviceStoreBase', () => {
 
       // Simulate 15 days of inactivity
       vi.advanceTimersByTime(FOURTEEN_DAYS + 1);
-      const devices = store.listDevices();
-      expect(devices).toHaveLength(0);
       expect(store.verifyToken(token).valid).toBe(false);
-      vi.useRealTimers();
+      expect(store.getDevice('d1')).toBeUndefined();
     });
   });
 

--- a/tests/unit/shared/device-store-base.test.ts
+++ b/tests/unit/shared/device-store-base.test.ts
@@ -16,6 +16,9 @@ class TestDeviceStore extends DeviceStoreBase {
   public cleanupExpiredRequestsPublic(): void {
     this.cleanupExpiredRequests();
   }
+  public cleanupInactiveDevicesPublic(): void {
+    this.cleanupInactiveDevices();
+  }
 }
 
 describe('DeviceStoreBase', () => {
@@ -59,7 +62,7 @@ describe('DeviceStoreBase', () => {
       const id = store.generateDeviceId();
       expect(id).toMatch(/^[a-f0-9]+$/);
 
-      const device = { id, name: 'Test', lastSeenAt: 123 } as any;
+      const device = { id, name: 'Test', lastSeenAt: Date.now() } as any;
       store.addDevice(device);
       expect(store.getDevice(id)).toEqual(device);
       expect(store.listDevices()).toContainEqual(device);
@@ -223,12 +226,85 @@ describe('DeviceStoreBase', () => {
     });
 
     it('sorts devices by lastSeenAt descending', () => {
-      store.addDevice({ id: 'd1', lastSeenAt: 100 } as any);
-      store.addDevice({ id: 'd2', lastSeenAt: 300 } as any);
-      store.addDevice({ id: 'd3', lastSeenAt: 200 } as any);
+      const now = Date.now();
+      store.addDevice({ id: 'd1', lastSeenAt: now - 2000 } as any);
+      store.addDevice({ id: 'd2', lastSeenAt: now } as any);
+      store.addDevice({ id: 'd3', lastSeenAt: now - 1000 } as any);
 
       const sorted = store.listDevices();
       expect(sorted.map(d => d.id)).toEqual(['d2', 'd3', 'd1']);
+    });
+  });
+
+  describe('Inactive Device Auto-Cleanup', () => {
+    const FOURTEEN_DAYS = 14 * 24 * 60 * 60 * 1000;
+
+    it('removes non-host devices inactive for more than 14 days', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'd1', lastSeenAt: now - FOURTEEN_DAYS - 1, isHost: false } as any);
+      store.addDevice({ id: 'd2', lastSeenAt: now - FOURTEEN_DAYS + 60000, isHost: false } as any);
+
+      store.cleanupInactiveDevicesPublic();
+
+      expect(store.getDevice('d1')).toBeUndefined();
+      expect(store.getDevice('d2')).toBeDefined();
+      vi.useRealTimers();
+    });
+
+    it('never removes host devices regardless of inactivity', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'host', lastSeenAt: now - FOURTEEN_DAYS - 1, isHost: true } as any);
+      store.addDevice({ id: 'remote', lastSeenAt: now - FOURTEEN_DAYS - 1, isHost: false } as any);
+
+      store.cleanupInactiveDevicesPublic();
+
+      expect(store.getDevice('host')).toBeDefined();
+      expect(store.getDevice('remote')).toBeUndefined();
+      vi.useRealTimers();
+    });
+
+    it('triggers cleanup when listing devices', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'stale', lastSeenAt: now - FOURTEEN_DAYS - 1 } as any);
+      store.addDevice({ id: 'active', lastSeenAt: now } as any);
+
+      const devices = store.listDevices();
+      expect(devices).toHaveLength(1);
+      expect(devices[0].id).toBe('active');
+      vi.useRealTimers();
+    });
+
+    it('triggers cleanup via cleanupExpiredRequests', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'stale', lastSeenAt: now - FOURTEEN_DAYS - 1 } as any);
+      store.cleanupExpiredRequestsPublic();
+
+      expect(store.getDevice('stale')).toBeUndefined();
+      vi.useRealTimers();
+    });
+
+    it('invalidates tokens for cleaned-up devices', () => {
+      vi.useFakeTimers();
+      const now = Date.now();
+
+      store.addDevice({ id: 'd1', lastSeenAt: now } as any);
+      const token = store.generateToken('d1');
+      expect(store.verifyToken(token).valid).toBe(true);
+
+      // Simulate 15 days of inactivity
+      vi.advanceTimersByTime(FOURTEEN_DAYS + 1);
+      const devices = store.listDevices();
+      expect(devices).toHaveLength(0);
+      expect(store.verifyToken(token).valid).toBe(false);
+      vi.useRealTimers();
     });
   });
 


### PR DESCRIPTION
## Summary

Automatically remove authorized devices that have been inactive for more than 14 days, improving security for remote-access scenarios.

## Changes

- Add `DEVICE_INACTIVE_MS` constant (14 days) to `DeviceStoreBase`
- Add `cleanupInactiveDevices()` method that removes non-host devices with stale `lastSeenAt`
- Integrate cleanup into `listDevices()` and `cleanupExpiredRequests()` (lazy, no background timer)
- Host devices (`isHost: true`) are never auto-removed
- Add 5 unit tests covering cleanup behavior, host exemption, and token invalidation

## Notes

- IM channels (Feishu, etc.) are unaffected — they connect via internal WebSocket without device auth
- Tokens for cleaned-up devices are automatically invalidated (device no longer exists → `verifyToken` returns invalid)