### PR TITLE
feat: persist pinned sessions across app restarts

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -114,7 +114,8 @@ export default function Chat() {
   // Track sessions whose error/cancelled status has been dismissed by viewing
   const [dismissedSessions, setDismissedSessions] = createSignal<Set<string>>(new Set());
   // Active sessions: pin state + delayed removal for Active section
-  const [pinnedSessions, setPinnedSessions] = createSignal<Set<string>>(new Set());
+  const savedPins = getSetting<string[]>("pinnedSessions") ?? [];
+  const [pinnedSessions, setPinnedSessions] = createSignal<Set<string>>(new Set(savedPins));
   const [delayingRemoval, setDelayingRemoval] = createSignal<Set<string>>(new Set());
   const delayTimers = new Map<string, ReturnType<typeof setTimeout>>();
   let prevSendingMap: Record<string, boolean> = {};
@@ -197,6 +198,7 @@ export default function Chat() {
     setPinnedSessions((prev) => {
       const next = new Set(prev);
       next.add(sid);
+      saveSetting("pinnedSessions", [...next]);
       return next;
     });
   };
@@ -205,6 +207,7 @@ export default function Chat() {
     setPinnedSessions((prev) => {
       const next = new Set(prev);
       next.delete(sid);
+      saveSetting("pinnedSessions", [...next]);
       return next;
     });
     // Cancel any pending delayed removal
@@ -811,7 +814,15 @@ export default function Chat() {
 
           setSessionStore("list", sessionInfos);
 
-          // Load scheduled tasks (only if feature is enabled)
+          // Prune pinned session IDs that no longer exist
+          const validIds = new Set(sessionInfos.map(s => s.id));
+          setPinnedSessions((prev) => {
+            const pruned = new Set([...prev].filter(id => validIds.has(id)));
+            if (pruned.size !== prev.size) {
+              saveSetting("pinnedSessions", [...pruned]);
+            }
+            return pruned;
+          });
           if (scheduledTaskStore.enabled) {
             try {
               const tasks = await gateway.listScheduledTasks();

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -114,7 +114,10 @@ export default function Chat() {
   // Track sessions whose error/cancelled status has been dismissed by viewing
   const [dismissedSessions, setDismissedSessions] = createSignal<Set<string>>(new Set());
   // Active sessions: pin state + delayed removal for Active section
-  const savedPins = getSetting<string[]>("pinnedSessions") ?? [];
+  const savedPinsSetting = getSetting<unknown>("pinnedSessions");
+  const savedPins = Array.isArray(savedPinsSetting)
+    ? savedPinsSetting.filter((pin): pin is string => typeof pin === "string")
+    : [];
   const [pinnedSessions, setPinnedSessions] = createSignal<Set<string>>(new Set(savedPins));
   const [delayingRemoval, setDelayingRemoval] = createSignal<Set<string>>(new Set());
   const delayTimers = new Map<string, ReturnType<typeof setTimeout>>();


### PR DESCRIPTION
## Summary
- Pinned (active) sessions are now persisted via the existing `saveSetting`/`getSetting` layer (`settings.json` in Electron, `localStorage` in web)
- On app startup, pinned session IDs are restored from settings and stale IDs (deleted sessions) are automatically pruned
- Zero new infrastructure — reuses the same persistence mechanism as `lastSessionId`

## Test plan
- [ ] Pin several sessions, restart the app, verify they remain pinned in the Active section
- [ ] Unpin a session, restart, verify it's no longer pinned
- [ ] Delete a pinned session, restart, verify the stale ID is cleaned up from settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)