### PR TITLE
fix: restore chat scroll position after navigation and session switch

### DIFF
--- a/src/lib/scroll-position.ts
+++ b/src/lib/scroll-position.ts
@@ -36,19 +36,11 @@ export function resolveRemountScroll(currentSessionId: string | null): ScrollAct
 }
 
 /**
- * Decide scroll behavior when switching sessions.
- * - No existing messages → caller should load from disk (not handled here)
+ * Decide scroll behavior when switching to a session that already has messages.
  * - Has saved position → restore it
  * - No saved position → scroll to bottom
  */
-export function resolveSessionSwitchScroll(
-  sessionId: string,
-  hasExistingMessages: boolean,
-): ScrollAction {
-  if (!hasExistingMessages) {
-    // Caller should load from disk, which scrolls to bottom internally
-    return { action: "none" };
-  }
+export function resolveSessionSwitchScroll(sessionId: string): ScrollAction {
   const savedPos = savedScrollPositions.get(sessionId);
   if (savedPos !== undefined) {
     return { action: "restore", position: savedPos };

--- a/src/lib/scroll-position.ts
+++ b/src/lib/scroll-position.ts
@@ -1,0 +1,57 @@
+// Scroll position cache — persists across component mount/unmount cycles
+// so navigating away (e.g. Settings) and back restores the scroll position.
+
+const savedScrollPositions = new Map<string, number>();
+
+export type ScrollAction =
+  | { action: "restore"; position: number }
+  | { action: "scrollToBottom" }
+  | { action: "none" };
+
+/**
+ * Save scroll position for a session.
+ */
+export function saveScrollPosition(sessionId: string, scrollTop: number): void {
+  savedScrollPositions.set(sessionId, scrollTop);
+}
+
+/**
+ * Delete scroll position for a session (e.g. when session is deleted).
+ */
+export function deleteScrollPosition(sessionId: string): void {
+  savedScrollPositions.delete(sessionId);
+}
+
+/**
+ * Decide scroll behavior on component remount (e.g. returning from Settings).
+ * Returns saved position if available, otherwise "none".
+ */
+export function resolveRemountScroll(currentSessionId: string | null): ScrollAction {
+  if (!currentSessionId) return { action: "none" };
+  const savedPos = savedScrollPositions.get(currentSessionId);
+  if (savedPos !== undefined) {
+    return { action: "restore", position: savedPos };
+  }
+  return { action: "none" };
+}
+
+/**
+ * Decide scroll behavior when switching sessions.
+ * - No existing messages → caller should load from disk (not handled here)
+ * - Has saved position → restore it
+ * - No saved position → scroll to bottom
+ */
+export function resolveSessionSwitchScroll(
+  sessionId: string,
+  hasExistingMessages: boolean,
+): ScrollAction {
+  if (!hasExistingMessages) {
+    // Caller should load from disk, which scrolls to bottom internally
+    return { action: "none" };
+  }
+  const savedPos = savedScrollPositions.get(sessionId);
+  if (savedPos !== undefined) {
+    return { action: "restore", position: savedPos };
+  }
+  return { action: "scrollToBottom" };
+}

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -937,7 +937,7 @@ export default function Chat() {
     if (!existing || !existing.some(m => m.role === "user")) {
       await loadSessionMessages(sessionId);
     } else {
-      const scrollAction = resolveSessionSwitchScroll(sessionId, true);
+      const scrollAction = resolveSessionSwitchScroll(sessionId);
       if (scrollAction.action === "restore") {
         const pos = scrollAction.position;
         setTimeout(() => {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -95,6 +95,10 @@ function toSessionInfo(s: UnifiedSession, projectID?: string): SessionInfo {
   };
 }
 
+// Module-level scroll position cache — persists across mount/unmount cycles
+// so navigating away (e.g. Settings) and back restores the scroll position.
+const savedScrollPositions = new Map<string, number>();
+
 export default function Chat() {
   const { t } = useI18n();
   const navigate = useNavigate();
@@ -547,6 +551,12 @@ export default function Chat() {
     scrollRafId2 = requestAnimationFrame(() => {
       scrollRafPending = false;
       setUserScrolledUp(!isNearBottom());
+      // Persist scroll position so it survives navigation and session switches
+      const sid = sessionStore.current;
+      const el = messagesRef();
+      if (sid && el) {
+        savedScrollPositions.set(sid, el.scrollTop);
+      }
     });
   };
   onCleanup(() => {
@@ -757,6 +767,17 @@ export default function Chat() {
 
       if (!needsSessionBootstrap) {
         logger.debug("[Init] Gateway already initialized, handlers refreshed (remount)");
+        // Restore scroll position for the current session after route navigation
+        const sid = sessionStore.current;
+        if (sid) {
+          const savedPos = savedScrollPositions.get(sid);
+          if (savedPos !== undefined) {
+            setTimeout(() => {
+              const el = messagesRef();
+              if (el) el.scrollTop = savedPos;
+            }, 50);
+          }
+        }
         return;
       }
 
@@ -855,6 +876,14 @@ export default function Chat() {
   const handleSelectSession = async (sessionId: string) => {
     const gen = ++switchGeneration;
     logger.debug("[SelectSession] Switching to session:", sessionId);
+
+    // Save scroll position of the outgoing session before switching
+    const prevSid = sessionStore.current;
+    const prevEl = messagesRef();
+    if (prevSid && prevEl) {
+      savedScrollPositions.set(prevSid, prevEl.scrollTop);
+    }
+
     setSessionStore("current", sessionId);
     setSessionStore("initError", null);
 
@@ -913,7 +942,16 @@ export default function Chat() {
     if (!existing || !existing.some(m => m.role === "user")) {
       await loadSessionMessages(sessionId);
     } else {
-      setTimeout(() => scrollToBottomStable(), 100);
+      // Restore saved scroll position if available, otherwise scroll to bottom
+      const savedPos = savedScrollPositions.get(sessionId);
+      if (savedPos !== undefined) {
+        setTimeout(() => {
+          const el = messagesRef();
+          if (el) el.scrollTop = savedPos;
+        }, 100);
+      } else {
+        setTimeout(() => scrollToBottomStable(), 100);
+      }
     }
 
     // Stale check: if the user has already switched to another session

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -40,6 +40,7 @@ import { formatTokenCount, formatCostWithUnit, getEngineBadge } from "../compone
 import { getSetting, saveSetting, bootstrapHostSettings } from "../lib/settings";
 import { refreshThemeFromSettings } from "../lib/theme";
 import { refreshLocaleFromSettings } from "../lib/i18n";
+import { saveScrollPosition, deleteScrollPosition, resolveRemountScroll, resolveSessionSwitchScroll } from "../lib/scroll-position";
 
 import { InputAreaQuestion } from "../components/InputAreaQuestion";
 import { InputAreaPermission } from "../components/InputAreaPermission";
@@ -94,10 +95,6 @@ function toSessionInfo(s: UnifiedSession, projectID?: string): SessionInfo {
     updatedAt: new Date(s.time.updated).toISOString(),
   };
 }
-
-// Module-level scroll position cache — persists across mount/unmount cycles
-// so navigating away (e.g. Settings) and back restores the scroll position.
-const savedScrollPositions = new Map<string, number>();
 
 export default function Chat() {
   const { t } = useI18n();
@@ -555,7 +552,7 @@ export default function Chat() {
       const sid = sessionStore.current;
       const el = messagesRef();
       if (sid && el) {
-        savedScrollPositions.set(sid, el.scrollTop);
+        saveScrollPosition(sid, el.scrollTop);
       }
     });
   };
@@ -768,15 +765,13 @@ export default function Chat() {
       if (!needsSessionBootstrap) {
         logger.debug("[Init] Gateway already initialized, handlers refreshed (remount)");
         // Restore scroll position for the current session after route navigation
-        const sid = sessionStore.current;
-        if (sid) {
-          const savedPos = savedScrollPositions.get(sid);
-          if (savedPos !== undefined) {
-            setTimeout(() => {
-              const el = messagesRef();
-              if (el) el.scrollTop = savedPos;
-            }, 50);
-          }
+        const scrollAction = resolveRemountScroll(sessionStore.current);
+        if (scrollAction.action === "restore") {
+          const pos = scrollAction.position;
+          setTimeout(() => {
+            const el = messagesRef();
+            if (el) el.scrollTop = pos;
+          }, 50);
         }
         return;
       }
@@ -881,7 +876,7 @@ export default function Chat() {
     const prevSid = sessionStore.current;
     const prevEl = messagesRef();
     if (prevSid && prevEl) {
-      savedScrollPositions.set(prevSid, prevEl.scrollTop);
+      saveScrollPosition(prevSid, prevEl.scrollTop);
     }
 
     setSessionStore("current", sessionId);
@@ -942,15 +937,19 @@ export default function Chat() {
     if (!existing || !existing.some(m => m.role === "user")) {
       await loadSessionMessages(sessionId);
     } else {
-      // Restore saved scroll position if available, otherwise scroll to bottom
-      const savedPos = savedScrollPositions.get(sessionId);
-      if (savedPos !== undefined) {
+      const scrollAction = resolveSessionSwitchScroll(sessionId, true);
+      if (scrollAction.action === "restore") {
+        const pos = scrollAction.position;
         setTimeout(() => {
+          if (gen !== switchGeneration || sessionStore.current !== sessionId) return;
           const el = messagesRef();
-          if (el) el.scrollTop = savedPos;
+          if (el) el.scrollTop = pos;
         }, 100);
       } else {
-        setTimeout(() => scrollToBottomStable(), 100);
+        setTimeout(() => {
+          if (gen !== switchGeneration || sessionStore.current !== sessionId) return;
+          scrollToBottomStable();
+        }, 100);
       }
     }
 
@@ -1052,6 +1051,8 @@ export default function Chat() {
         setTodoPartRef(null);
       }
 
+      deleteScrollPosition(sessionId);
+
       // Remove from list
       setSessionStore("list", (list) => list.filter((s) => s.id !== sessionId));
 
@@ -1150,6 +1151,7 @@ export default function Chat() {
         setMessageStore("permission", session.id, undefined as any);
         setMessageStore("question", session.id, undefined as any);
         setMessageStore("queued", session.id, undefined as any);
+        deleteScrollPosition(session.id);
       }
 
       setSessionStore("list", (list) =>

--- a/tests/unit/src/components/scroll-position-restore.test.ts
+++ b/tests/unit/src/components/scroll-position-restore.test.ts
@@ -2,107 +2,60 @@
 // Unit tests: Scroll Position Restore
 //
 // Validates the scroll position save/restore logic for Chat navigation and
-// session switching. The module-level savedScrollPositions Map persists
-// across component mount/unmount cycles.
+// session switching. Tests the shared utility in src/lib/scroll-position.ts
+// which is used by Chat.tsx.
 //
 // Scenarios covered:
 //   1. Navigate Chat → Settings → Chat: restore saved position on remount
 //   2. Switch Session A → B → A: restore A's saved position
 //   3. First-time session view: no saved position → scroll to bottom
 //   4. Save overwrites previous position on scroll
+//   5. Cleanup on session delete prevents memory leak
 // =============================================================================
 
 import { describe, it, expect, beforeEach } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Helpers — mirror the scroll position logic from Chat.tsx
-// ---------------------------------------------------------------------------
-
-type ScrollAction =
-  | { action: "restore"; position: number }
-  | { action: "scrollToBottom" }
-  | { action: "loadFromDisk" }
-  | { action: "none" };
-
-/**
- * Decide scroll behavior when switching sessions (handleSelectSession).
- *
- * Mirrors Chat.tsx lines 941-953:
- * - No existing messages → load from disk (which scrolls to bottom internally)
- * - Has saved position → restore it
- * - No saved position → scroll to bottom
- */
-function resolveSessionSwitchScroll(
-  savedPositions: Map<string, number>,
-  sessionId: string,
-  hasExistingMessages: boolean,
-): ScrollAction {
-  if (!hasExistingMessages) {
-    return { action: "loadFromDisk" };
-  }
-  const savedPos = savedPositions.get(sessionId);
-  if (savedPos !== undefined) {
-    return { action: "restore", position: savedPos };
-  }
-  return { action: "scrollToBottom" };
-}
-
-/**
- * Decide scroll behavior on component remount (initializeSession early return).
- *
- * Mirrors Chat.tsx lines 768-781:
- * - No current session → do nothing
- * - Has saved position → restore it
- * - No saved position → do nothing (DOM starts at 0, no data to restore)
- */
-function resolveRemountScroll(
-  savedPositions: Map<string, number>,
-  currentSessionId: string | null,
-): ScrollAction {
-  if (!currentSessionId) return { action: "none" };
-  const savedPos = savedPositions.get(currentSessionId);
-  if (savedPos !== undefined) {
-    return { action: "restore", position: savedPos };
-  }
-  return { action: "none" };
-}
+import {
+  saveScrollPosition,
+  deleteScrollPosition,
+  resolveRemountScroll,
+  resolveSessionSwitchScroll,
+} from "../../../../src/lib/scroll-position";
 
 // ---------------------------------------------------------------------------
 // Tests: Remount scroll restore (Chat → Settings → Chat)
 // ---------------------------------------------------------------------------
 
 describe("remount scroll restore (Chat → Settings → Chat)", () => {
-  let cache: Map<string, number>;
-
   beforeEach(() => {
-    cache = new Map();
+    // Clean up any state from previous tests
+    deleteScrollPosition("session-1");
   });
 
   it("restores saved position after remount", () => {
-    cache.set("session-1", 420);
+    saveScrollPosition("session-1", 420);
 
-    const result = resolveRemountScroll(cache, "session-1");
+    const result = resolveRemountScroll("session-1");
     expect(result).toEqual({ action: "restore", position: 420 });
   });
 
   it("does nothing when no position was saved", () => {
-    const result = resolveRemountScroll(cache, "session-1");
+    const result = resolveRemountScroll("session-1");
     expect(result).toEqual({ action: "none" });
   });
 
   it("does nothing when there is no current session", () => {
-    cache.set("session-1", 420);
+    saveScrollPosition("session-1", 420);
 
-    const result = resolveRemountScroll(cache, null);
+    const result = resolveRemountScroll(null);
     expect(result).toEqual({ action: "none" });
   });
 
   it("restores the latest saved position after multiple scrolls", () => {
-    cache.set("session-1", 100);
-    cache.set("session-1", 200);
-    cache.set("session-1", 350);
+    saveScrollPosition("session-1", 100);
+    saveScrollPosition("session-1", 200);
+    saveScrollPosition("session-1", 350);
 
-    const result = resolveRemountScroll(cache, "session-1");
+    const result = resolveRemountScroll("session-1");
     expect(result).toEqual({ action: "restore", position: 350 });
   });
 });
@@ -112,90 +65,91 @@ describe("remount scroll restore (Chat → Settings → Chat)", () => {
 // ---------------------------------------------------------------------------
 
 describe("session switch scroll restore", () => {
-  let cache: Map<string, number>;
-
   beforeEach(() => {
-    cache = new Map();
+    deleteScrollPosition("session-a");
+    deleteScrollPosition("session-b");
+    deleteScrollPosition("session-c");
   });
 
   it("restores saved position when switching back to a viewed session", () => {
-    // User scrolls in session A
-    cache.set("session-a", 500);
+    saveScrollPosition("session-a", 500);
 
-    // Switch to B, then back to A
-    const result = resolveSessionSwitchScroll(cache, "session-a", true);
+    const result = resolveSessionSwitchScroll("session-a", true);
     expect(result).toEqual({ action: "restore", position: 500 });
   });
 
   it("scrolls to bottom for a session with no saved position", () => {
-    const result = resolveSessionSwitchScroll(cache, "session-b", true);
+    const result = resolveSessionSwitchScroll("session-b", true);
     expect(result).toEqual({ action: "scrollToBottom" });
   });
 
-  it("loads from disk when session has no existing messages", () => {
-    cache.set("session-a", 500);
+  it("returns none when session has no existing messages", () => {
+    saveScrollPosition("session-a", 500);
 
-    const result = resolveSessionSwitchScroll(cache, "session-a", false);
-    expect(result).toEqual({ action: "loadFromDisk" });
+    const result = resolveSessionSwitchScroll("session-a", false);
+    expect(result).toEqual({ action: "none" });
   });
 
   it("each session maintains its own independent scroll position", () => {
-    cache.set("session-a", 100);
-    cache.set("session-b", 800);
-    cache.set("session-c", 0);
+    saveScrollPosition("session-a", 100);
+    saveScrollPosition("session-b", 800);
+    saveScrollPosition("session-c", 0);
 
-    expect(resolveSessionSwitchScroll(cache, "session-a", true))
+    expect(resolveSessionSwitchScroll("session-a", true))
       .toEqual({ action: "restore", position: 100 });
-    expect(resolveSessionSwitchScroll(cache, "session-b", true))
+    expect(resolveSessionSwitchScroll("session-b", true))
       .toEqual({ action: "restore", position: 800 });
-    expect(resolveSessionSwitchScroll(cache, "session-c", true))
+    expect(resolveSessionSwitchScroll("session-c", true))
       .toEqual({ action: "restore", position: 0 });
   });
 
   it("saves outgoing session position before switch", () => {
-    // Simulate: user is at session-a scrollTop=300, switches to session-b
-    const outgoingSessionId = "session-a";
-    const outgoingScrollTop = 300;
-    cache.set(outgoingSessionId, outgoingScrollTop);
+    saveScrollPosition("session-a", 300);
 
-    // Later, switch back to session-a
-    const result = resolveSessionSwitchScroll(cache, "session-a", true);
+    const result = resolveSessionSwitchScroll("session-a", true);
     expect(result).toEqual({ action: "restore", position: 300 });
   });
 });
 
 // ---------------------------------------------------------------------------
-// Tests: Position persistence across mount/unmount cycles
+// Tests: Position persistence and cleanup
 // ---------------------------------------------------------------------------
 
 describe("scroll position cache persistence", () => {
-  it("module-level Map survives simulated mount/unmount cycles", () => {
-    // The cache lives outside the component — simulate multiple lifecycles
-    const cache = new Map<string, number>();
+  beforeEach(() => {
+    deleteScrollPosition("session-1");
+  });
 
+  it("module-level state survives across calls (simulated mount/unmount)", () => {
     // Mount 1: user scrolls
-    cache.set("session-1", 250);
+    saveScrollPosition("session-1", 250);
 
-    // Unmount (navigate to Settings) — cache is NOT cleared
+    // Unmount (navigate to Settings) — state is NOT cleared
 
     // Mount 2: check position is still there
-    expect(cache.get("session-1")).toBe(250);
+    expect(resolveRemountScroll("session-1")).toEqual({ action: "restore", position: 250 });
 
     // Mount 2: user scrolls further
-    cache.set("session-1", 600);
-
-    // Unmount again
+    saveScrollPosition("session-1", 600);
 
     // Mount 3: latest position preserved
-    expect(cache.get("session-1")).toBe(600);
+    expect(resolveRemountScroll("session-1")).toEqual({ action: "restore", position: 600 });
   });
 
   it("scroll position at 0 is a valid saved position", () => {
-    const cache = new Map<string, number>();
-    cache.set("session-1", 0);
+    saveScrollPosition("session-1", 0);
 
     // scrollTop=0 means user is at the top — should restore to top, not scroll to bottom
-    const result = resolveSessionSwitchScroll(cache, "session-1", true);
+    const result = resolveSessionSwitchScroll("session-1", true);
     expect(result).toEqual({ action: "restore", position: 0 });
+  });
+
+  it("deleteScrollPosition removes saved position (no memory leak on session delete)", () => {
+    saveScrollPosition("session-1", 420);
+    expect(resolveRemountScroll("session-1")).toEqual({ action: "restore", position: 420 });
+
+    deleteScrollPosition("session-1");
+    expect(resolveRemountScroll("session-1")).toEqual({ action: "none" });
+    expect(resolveSessionSwitchScroll("session-1", true)).toEqual({ action: "scrollToBottom" });
   });
 });

--- a/tests/unit/src/components/scroll-position-restore.test.ts
+++ b/tests/unit/src/components/scroll-position-restore.test.ts
@@ -1,0 +1,201 @@
+// =============================================================================
+// Unit tests: Scroll Position Restore
+//
+// Validates the scroll position save/restore logic for Chat navigation and
+// session switching. The module-level savedScrollPositions Map persists
+// across component mount/unmount cycles.
+//
+// Scenarios covered:
+//   1. Navigate Chat → Settings → Chat: restore saved position on remount
+//   2. Switch Session A → B → A: restore A's saved position
+//   3. First-time session view: no saved position → scroll to bottom
+//   4. Save overwrites previous position on scroll
+// =============================================================================
+
+import { describe, it, expect, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Helpers — mirror the scroll position logic from Chat.tsx
+// ---------------------------------------------------------------------------
+
+type ScrollAction =
+  | { action: "restore"; position: number }
+  | { action: "scrollToBottom" }
+  | { action: "loadFromDisk" }
+  | { action: "none" };
+
+/**
+ * Decide scroll behavior when switching sessions (handleSelectSession).
+ *
+ * Mirrors Chat.tsx lines 941-953:
+ * - No existing messages → load from disk (which scrolls to bottom internally)
+ * - Has saved position → restore it
+ * - No saved position → scroll to bottom
+ */
+function resolveSessionSwitchScroll(
+  savedPositions: Map<string, number>,
+  sessionId: string,
+  hasExistingMessages: boolean,
+): ScrollAction {
+  if (!hasExistingMessages) {
+    return { action: "loadFromDisk" };
+  }
+  const savedPos = savedPositions.get(sessionId);
+  if (savedPos !== undefined) {
+    return { action: "restore", position: savedPos };
+  }
+  return { action: "scrollToBottom" };
+}
+
+/**
+ * Decide scroll behavior on component remount (initializeSession early return).
+ *
+ * Mirrors Chat.tsx lines 768-781:
+ * - No current session → do nothing
+ * - Has saved position → restore it
+ * - No saved position → do nothing (DOM starts at 0, no data to restore)
+ */
+function resolveRemountScroll(
+  savedPositions: Map<string, number>,
+  currentSessionId: string | null,
+): ScrollAction {
+  if (!currentSessionId) return { action: "none" };
+  const savedPos = savedPositions.get(currentSessionId);
+  if (savedPos !== undefined) {
+    return { action: "restore", position: savedPos };
+  }
+  return { action: "none" };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: Remount scroll restore (Chat → Settings → Chat)
+// ---------------------------------------------------------------------------
+
+describe("remount scroll restore (Chat → Settings → Chat)", () => {
+  let cache: Map<string, number>;
+
+  beforeEach(() => {
+    cache = new Map();
+  });
+
+  it("restores saved position after remount", () => {
+    cache.set("session-1", 420);
+
+    const result = resolveRemountScroll(cache, "session-1");
+    expect(result).toEqual({ action: "restore", position: 420 });
+  });
+
+  it("does nothing when no position was saved", () => {
+    const result = resolveRemountScroll(cache, "session-1");
+    expect(result).toEqual({ action: "none" });
+  });
+
+  it("does nothing when there is no current session", () => {
+    cache.set("session-1", 420);
+
+    const result = resolveRemountScroll(cache, null);
+    expect(result).toEqual({ action: "none" });
+  });
+
+  it("restores the latest saved position after multiple scrolls", () => {
+    cache.set("session-1", 100);
+    cache.set("session-1", 200);
+    cache.set("session-1", 350);
+
+    const result = resolveRemountScroll(cache, "session-1");
+    expect(result).toEqual({ action: "restore", position: 350 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Session switch scroll restore (Session A → B → A)
+// ---------------------------------------------------------------------------
+
+describe("session switch scroll restore", () => {
+  let cache: Map<string, number>;
+
+  beforeEach(() => {
+    cache = new Map();
+  });
+
+  it("restores saved position when switching back to a viewed session", () => {
+    // User scrolls in session A
+    cache.set("session-a", 500);
+
+    // Switch to B, then back to A
+    const result = resolveSessionSwitchScroll(cache, "session-a", true);
+    expect(result).toEqual({ action: "restore", position: 500 });
+  });
+
+  it("scrolls to bottom for a session with no saved position", () => {
+    const result = resolveSessionSwitchScroll(cache, "session-b", true);
+    expect(result).toEqual({ action: "scrollToBottom" });
+  });
+
+  it("loads from disk when session has no existing messages", () => {
+    cache.set("session-a", 500);
+
+    const result = resolveSessionSwitchScroll(cache, "session-a", false);
+    expect(result).toEqual({ action: "loadFromDisk" });
+  });
+
+  it("each session maintains its own independent scroll position", () => {
+    cache.set("session-a", 100);
+    cache.set("session-b", 800);
+    cache.set("session-c", 0);
+
+    expect(resolveSessionSwitchScroll(cache, "session-a", true))
+      .toEqual({ action: "restore", position: 100 });
+    expect(resolveSessionSwitchScroll(cache, "session-b", true))
+      .toEqual({ action: "restore", position: 800 });
+    expect(resolveSessionSwitchScroll(cache, "session-c", true))
+      .toEqual({ action: "restore", position: 0 });
+  });
+
+  it("saves outgoing session position before switch", () => {
+    // Simulate: user is at session-a scrollTop=300, switches to session-b
+    const outgoingSessionId = "session-a";
+    const outgoingScrollTop = 300;
+    cache.set(outgoingSessionId, outgoingScrollTop);
+
+    // Later, switch back to session-a
+    const result = resolveSessionSwitchScroll(cache, "session-a", true);
+    expect(result).toEqual({ action: "restore", position: 300 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: Position persistence across mount/unmount cycles
+// ---------------------------------------------------------------------------
+
+describe("scroll position cache persistence", () => {
+  it("module-level Map survives simulated mount/unmount cycles", () => {
+    // The cache lives outside the component — simulate multiple lifecycles
+    const cache = new Map<string, number>();
+
+    // Mount 1: user scrolls
+    cache.set("session-1", 250);
+
+    // Unmount (navigate to Settings) — cache is NOT cleared
+
+    // Mount 2: check position is still there
+    expect(cache.get("session-1")).toBe(250);
+
+    // Mount 2: user scrolls further
+    cache.set("session-1", 600);
+
+    // Unmount again
+
+    // Mount 3: latest position preserved
+    expect(cache.get("session-1")).toBe(600);
+  });
+
+  it("scroll position at 0 is a valid saved position", () => {
+    const cache = new Map<string, number>();
+    cache.set("session-1", 0);
+
+    // scrollTop=0 means user is at the top — should restore to top, not scroll to bottom
+    const result = resolveSessionSwitchScroll(cache, "session-1", true);
+    expect(result).toEqual({ action: "restore", position: 0 });
+  });
+});

--- a/tests/unit/src/lib/scroll-position.test.ts
+++ b/tests/unit/src/lib/scroll-position.test.ts
@@ -74,20 +74,13 @@ describe("session switch scroll restore", () => {
   it("restores saved position when switching back to a viewed session", () => {
     saveScrollPosition("session-a", 500);
 
-    const result = resolveSessionSwitchScroll("session-a", true);
+    const result = resolveSessionSwitchScroll("session-a");
     expect(result).toEqual({ action: "restore", position: 500 });
   });
 
   it("scrolls to bottom for a session with no saved position", () => {
-    const result = resolveSessionSwitchScroll("session-b", true);
+    const result = resolveSessionSwitchScroll("session-b");
     expect(result).toEqual({ action: "scrollToBottom" });
-  });
-
-  it("returns none when session has no existing messages", () => {
-    saveScrollPosition("session-a", 500);
-
-    const result = resolveSessionSwitchScroll("session-a", false);
-    expect(result).toEqual({ action: "none" });
   });
 
   it("each session maintains its own independent scroll position", () => {
@@ -95,18 +88,18 @@ describe("session switch scroll restore", () => {
     saveScrollPosition("session-b", 800);
     saveScrollPosition("session-c", 0);
 
-    expect(resolveSessionSwitchScroll("session-a", true))
+    expect(resolveSessionSwitchScroll("session-a"))
       .toEqual({ action: "restore", position: 100 });
-    expect(resolveSessionSwitchScroll("session-b", true))
+    expect(resolveSessionSwitchScroll("session-b"))
       .toEqual({ action: "restore", position: 800 });
-    expect(resolveSessionSwitchScroll("session-c", true))
+    expect(resolveSessionSwitchScroll("session-c"))
       .toEqual({ action: "restore", position: 0 });
   });
 
   it("saves outgoing session position before switch", () => {
     saveScrollPosition("session-a", 300);
 
-    const result = resolveSessionSwitchScroll("session-a", true);
+    const result = resolveSessionSwitchScroll("session-a");
     expect(result).toEqual({ action: "restore", position: 300 });
   });
 });
@@ -140,7 +133,7 @@ describe("scroll position cache persistence", () => {
     saveScrollPosition("session-1", 0);
 
     // scrollTop=0 means user is at the top — should restore to top, not scroll to bottom
-    const result = resolveSessionSwitchScroll("session-1", true);
+    const result = resolveSessionSwitchScroll("session-1");
     expect(result).toEqual({ action: "restore", position: 0 });
   });
 
@@ -150,6 +143,6 @@ describe("scroll position cache persistence", () => {
 
     deleteScrollPosition("session-1");
     expect(resolveRemountScroll("session-1")).toEqual({ action: "none" });
-    expect(resolveSessionSwitchScroll("session-1", true)).toEqual({ action: "scrollToBottom" });
+    expect(resolveSessionSwitchScroll("session-1")).toEqual({ action: "scrollToBottom" });
   });
 });


### PR DESCRIPTION
## Summary

Navigating from Chat to Settings/Devices and back resets scroll to top. Switching between sessions also loses scroll position (always scrolls to bottom).

**Root cause**: Chat component is fully destroyed/recreated on route navigation. On remount, `initializeSession()` returns early (sessions already in store) with no scroll restoration. Session switch unconditionally calls `scrollToBottomStable()`.

**Fix**: Module-level `savedScrollPositions` Map persists scroll positions per session across mount/unmount cycles:
- `handleScroll`: save `scrollTop` on every scroll event
- `initializeSession` (remount early return): restore saved position
- `handleSelectSession`: save outgoing session position, restore incoming session position (or scroll-to-bottom if first visit)

Unchanged behaviors: new session creation, first-time disk load, and user sending a message still scroll to bottom as expected.

## Test plan

- [ ] Open a chat with messages, scroll up, navigate to Settings, navigate back → scroll position preserved
- [ ] Switch Session A → Session B → Session A → A's scroll position preserved
- [ ] Open a session for the first time → scrolls to bottom (no saved position)
- [ ] Send a message → scrolls to bottom
- [ ] Create new session → scrolls to bottom
- [ ] Unit tests pass: `bun run test:unit` (500 tests, 11 new)