### PR TITLE
fix: improve proxy auth detection for Claude Code and Codex engines

### DIFF
--- a/electron/main/engines/claude/index.ts
+++ b/electron/main/engines/claude/index.ts
@@ -151,6 +151,28 @@ export function getClaudeReasoningCapabilities(
 }
 
 // ============================================================================
+// Read ~/.claude/settings.json env field for proxy auth detection
+// ============================================================================
+
+function readClaudeSettingsEnv(): Record<string, string> {
+  try {
+    const settingsPath = join(homedir(), ".claude", "settings.json");
+    if (!existsSync(settingsPath)) return {};
+    const settings = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    if (settings && typeof settings.env === "object" && settings.env !== null) {
+      const env: Record<string, string> = {};
+      for (const [key, value] of Object.entries(settings.env)) {
+        if (typeof value === "string") env[key] = value;
+      }
+      return env;
+    }
+  } catch (err) {
+    claudeLog.warn("[Claude] Failed to read ~/.claude/settings.json env:", err);
+  }
+  return {};
+}
+
+// ============================================================================
 // Session idle timeout (30 min)
 // ============================================================================
 
@@ -293,6 +315,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     try {
       const env: Record<string, string | undefined> = {
         ...process.env,
+        ...readClaudeSettingsEnv(),
         ...this.options?.env,
       };
       const sdkEnv = { ...env };
@@ -974,6 +997,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
   private async refreshModelCache(): Promise<void> {
     const env: Record<string, string | undefined> = {
       ...process.env,
+      ...readClaudeSettingsEnv(),
       ...this.options?.env,
     };
 

--- a/electron/main/engines/codex/index.ts
+++ b/electron/main/engines/codex/index.ts
@@ -1,5 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
-import { tmpdir } from "os";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { tmpdir, homedir } from "os";
 import { join } from "path";
 
 import type {
@@ -76,6 +76,28 @@ const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const START_TIMEOUT_MS = 120_000;
 const DEFAULT_MODE_ID = "default";
 const MAX_IMAGE_ATTACHMENT_BYTES = 3 * 1024 * 1024;
+
+/**
+ * Read the `model_provider` field from `~/.codex/config.toml`.
+ * Uses simple line parsing to avoid a TOML dependency.
+ */
+function readCodexModelProvider(): string | undefined {
+  try {
+    const configPath = join(homedir(), ".codex", "config.toml");
+    if (!existsSync(configPath)) return undefined;
+    const content = readFileSync(configPath, "utf-8");
+    // Match top-level `model_provider = "..."` (before any [section] header)
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith("[")) break; // entered a section
+      const match = trimmed.match(/^model_provider\s*=\s*"([^"]+)"/);
+      if (match) return match[1];
+    }
+  } catch (err) {
+    codexLog.warn("[Codex] Failed to read ~/.codex/config.toml:", err);
+  }
+  return undefined;
+}
 
 type CodexTurnInput =
   | { type: "text"; text: string; text_elements: unknown[] }
@@ -843,7 +865,7 @@ export class CodexAdapter extends EngineAdapter {
     // (e.g. custom model_provider in config.toml), treat as authenticated.
     if (!this.authenticated && this.cachedModels.length > 0) {
       this.authenticated = true;
-      this.authMessage ??= "Authenticated";
+      this.authMessage = readCodexModelProvider() ?? "Authenticated";
     }
   }
 


### PR DESCRIPTION
## Problem

When using proxy configurations, engine auth status was incorrectly reported:

- **Claude Code**: Proxy credentials configured in `~/.claude/settings.json` (via the `env` field) were not visible to `accountInfo()`, causing `tokenSource: "none"` even though the proxy was fully functional.
- **Codex**: When using `model_provider` in `~/.codex/config.toml`, the fallback auth message showed generic "Authenticated" instead of the provider name. Additionally, a `??=` operator bug prevented the message from being updated when `refreshAuthStatus()` had already set it to "Not authenticated".

## Solution

### Claude Code (`electron/main/engines/claude/index.ts`)
- Added `readClaudeSettingsEnv()` helper to read the `env` field from `~/.claude/settings.json`
- Merged settings env into subprocess environment in both `checkAuthentication()` and `refreshModelCache()`
- Auth display now shows the actual token source (e.g., `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`)

### Codex (`electron/main/engines/codex/index.ts`)
- Added `readCodexModelProvider()` helper to parse `model_provider` from `~/.codex/config.toml`
- Fixed `??=` → `=` in fallback auth logic so the provider name is always set
- Auth display now shows the provider name (e.g., `copilot-proxy`)

## Verification
- Typecheck passes
- All 2219 unit tests pass
- Manually tested: Claude Code with `ANTHROPIC_AUTH_TOKEN` in settings.json now shows correct auth status