### PR TITLE
fix(claude): include ~/.claude/settings.json env vars in all CLI subprocesses

### DIFF
--- a/electron/main/engines/claude/index.ts
+++ b/electron/main/engines/claude/index.ts
@@ -1799,6 +1799,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     // Build environment variables
     const env: Record<string, string | undefined> = {
       ...process.env,
+      ...readClaudeSettingsEnv(),
       ...this.options?.env,
     };
     // Don't let stale env var override the user's model selection
@@ -2041,6 +2042,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     const cwd = directory.replaceAll("/", process.platform === "win32" ? "\\" : "/");
     const env: Record<string, string | undefined> = {
       ...process.env,
+      ...readClaudeSettingsEnv(),
       ...this.options?.env,
     };
     delete env.ANTHROPIC_MODEL;


### PR DESCRIPTION
## Problem

PR #109 added `readClaudeSettingsEnv()` and applied it to `checkAuthentication()` and `refreshModelCache()`, but two other code paths that also spawn CLI subprocesses were missed. Sessions still fail with "Not logged in" when auth relies on `~/.claude/settings.json` env vars.

## Fix

Apply `readClaudeSettingsEnv()` to the remaining two env-building sites:

- `getOrCreateV2Session()` - Session subprocess creation/reuse
- `warmupV2Session()` - Command list warmup

## Testing

- TypeScript type-check passes
- All 244 Claude adapter unit tests pass
