### PR TITLE
fix: ensure time.completed is always set on finished assistant messages

### DIFF
--- a/electron/main/gateway/engine-manager.ts
+++ b/electron/main/gateway/engine-manager.ts
@@ -871,6 +871,17 @@ export class EngineManager extends EventEmitter {
       this.engineToConvMap.delete(engineSessionId);
     }
 
+    // Ensure completed assistant messages always have time.completed.
+    // Some adapters (e.g. OpenCode) strip time.completed during multi-step loops
+    // and only restore it on session.idle — if that event is lost (e.g. WebSocket
+    // reconnect), the field stays undefined, causing the frontend timer to tick
+    // indefinitely on an already-finished message.
+    if (result.role === "assistant" && !result.time.completed) {
+      const finalized = { ...result, time: { ...result.time, completed: Date.now() } };
+      this.persistMessage(sessionId, finalized);
+      this.emit("message.updated", { sessionId, message: finalized });
+    }
+
     return result;
     } finally {
       this.activeSessions.delete(sessionId);

--- a/src/components/SessionTurn.tsx
+++ b/src/components/SessionTurn.tsx
@@ -572,12 +572,25 @@ export function SessionTurn(props: SessionTurnProps) {
   // since isWorking reactivity can be lost through Index/prop chain.
   const [tick, setTick] = createSignal(Date.now());
 
+  // Safety-net end time: captured once when we first notice the session is done
+  // but time.completed is missing (e.g. session.idle event was dropped).
+  const [capturedEndTime, setCapturedEndTime] = createSignal<number | undefined>();
+
   const finalEndTime = createMemo(() => {
     // Only trust time.completed when isWorking is false — during multi-step
     // tasks, intermediate messages may carry completed timestamps prematurely.
     if (props.isWorking) return undefined;
     const lastAssistant = props.assistantMessages.at(-1);
-    return lastAssistant?.time?.completed ?? lastAssistant?.time?.created;
+    return lastAssistant?.time?.completed ?? capturedEndTime();
+  });
+
+  createEffect(() => {
+    if (!props.isWorking && !capturedEndTime()) {
+      const lastAssistant = props.assistantMessages.at(-1);
+      if (lastAssistant && !lastAssistant.time?.completed) {
+        setCapturedEndTime(Date.now());
+      }
+    }
   });
 
   createEffect(() => {

--- a/src/components/SessionTurn.tsx
+++ b/src/components/SessionTurn.tsx
@@ -577,7 +577,7 @@ export function SessionTurn(props: SessionTurnProps) {
     // tasks, intermediate messages may carry completed timestamps prematurely.
     if (props.isWorking) return undefined;
     const lastAssistant = props.assistantMessages.at(-1);
-    return lastAssistant?.time?.completed;
+    return lastAssistant?.time?.completed ?? lastAssistant?.time?.created;
   });
 
   createEffect(() => {


### PR DESCRIPTION
## Summary

Fix timer on inactive sessions: when switching to a chat with completed AI responses, the elapsed time counter was incorrectly ticking instead of showing a static value.

Supersedes #87 — incorporates the review feedback with a two-layer fix.

## Root Cause

Some adapters (e.g. OpenCode) strip `time.completed` during multi-step agent loops and only restore it on `session.idle`. If that event is dropped (e.g. during a WebSocket reconnect), the field stays `undefined`, causing the frontend timer to tick indefinitely. Additionally, `persistMessage()` in engine-manager skips messages without `time.completed`, so they never hit disk.

## Changes

### 1. Engine-manager root-cause fix (`engine-manager.ts`)
When `sendMessage()` returns an assistant message without `time.completed`, set it to `Date.now()`, persist and emit the finalized message.

### 2. Frontend safety net (`SessionTurn.tsx`)
Replace the `time.created` fallback (which showed ~0s duration) with a `capturedEndTime` signal that snapshots `Date.now()` once when the session is first observed as done without `time.completed`. This gives an approximately correct duration for any remaining edge cases.

## Credit

Original bug report and initial fix by @OverCart345 in #87.

## Test Plan

- [x] Type check passes (`npm run typecheck`)
- [x] Unit tests pass (`bun run test:unit` — 429 passed)

Co-authored-by: OverCart345 <82957545+OverCart345@users.noreply.github.com>