### PR TITLE
fix: sync reasoning effort and service tier settings in web mode

### DIFF
--- a/shared/settings-keys.ts
+++ b/shared/settings-keys.ts
@@ -11,6 +11,8 @@ export const SHARED_SETTINGS_KEYS = [
   "showDefaultWorkspace",
   "scheduledTasksEnabled",
   "worktreeEnabled",
+  "engineReasoningEfforts",
+  "engineServiceTiers",
 ] as const;
 
 export type SharedSettingsKey = (typeof SHARED_SETTINGS_KEYS)[number];
@@ -27,6 +29,8 @@ export function isSharedSettingsKey(key: string): key is SharedSettingsKey {
 
 const VALID_THEMES = new Set(["light", "dark", "system"]);
 const VALID_LOCALES = new Set(["en", "zh", "ru"]);
+const VALID_REASONING_EFFORTS = new Set(["low", "medium", "high", "max"]);
+const VALID_SERVICE_TIERS = new Set(["fast", "flex"]);
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -66,6 +70,28 @@ export function isValidSharedSettingValue(key: SharedSettingsKey, value: unknown
             return false;
           }
         }
+      }
+      return true;
+    }
+    case "engineReasoningEfforts": {
+      if (!isPlainObject(value)) return false;
+      const entries = Object.entries(value);
+      if (entries.length > 16) return false;
+      for (const [engineKey, v] of entries) {
+        if (engineKey === "__proto__" || engineKey === "constructor" || engineKey === "prototype") return false;
+        if (engineKey.length === 0 || engineKey.length > 64) return false;
+        if (typeof v !== "string" || !VALID_REASONING_EFFORTS.has(v)) return false;
+      }
+      return true;
+    }
+    case "engineServiceTiers": {
+      if (!isPlainObject(value)) return false;
+      const entries = Object.entries(value);
+      if (entries.length > 16) return false;
+      for (const [engineKey, v] of entries) {
+        if (engineKey === "__proto__" || engineKey === "constructor" || engineKey === "prototype") return false;
+        if (engineKey.length === 0 || engineKey.length > 64) return false;
+        if (v !== null && (typeof v !== "string" || !VALID_SERVICE_TIERS.has(v))) return false;
       }
       return true;
     }

--- a/tests/unit/shared/auth-route-handlers.test.ts
+++ b/tests/unit/shared/auth-route-handlers.test.ts
@@ -344,6 +344,8 @@ describe('auth-route-handlers', () => {
         locale: 'zh',
         logLevel: 'debug',
         engineModels: { claude: { providerID: 'anthropic', modelID: 'sonnet' } },
+        engineReasoningEfforts: { claude: 'max' },
+        engineServiceTiers: { codex: 'fast', opencode: null },
         lastSessionId: 'sess-123',
         someInternalKey: 'secret',
       });
@@ -356,6 +358,8 @@ describe('auth-route-handlers', () => {
         theme: 'dark',
         locale: 'zh',
         engineModels: { claude: { providerID: 'anthropic', modelID: 'sonnet' } },
+        engineReasoningEfforts: { claude: 'max' },
+        engineServiceTiers: { codex: 'fast', opencode: null },
         serverMode: process.env.CODEMUX_SERVER_MODE === "1",
       });
       // Sensitive keys must not leak
@@ -400,6 +404,24 @@ describe('auth-route-handlers', () => {
 
       expect(await handleSettingsRoutes(req, mockRes, pathname, mockStore, mockSettingsFns)).toBe(true);
       expect(mockSettingsFns.saveSettings).toHaveBeenCalledWith({ theme: 'light', locale: 'en' });
+      const responseBody = JSON.parse((mockRes.end as any).mock.calls[0][0]);
+      expect(responseBody.success).toBe(true);
+    });
+
+    it('PATCH saves valid reasoning effort and service tier settings', async () => {
+      const pathname = '/api/settings/shared';
+      const req = createMockReq(pathname, 'PATCH', {
+        engineReasoningEfforts: { claude: 'high' },
+        engineServiceTiers: { codex: 'fast', opencode: null },
+      });
+      req.headers.authorization = 'Bearer valid-token';
+      mockStore.verifyToken.mockReturnValue({ valid: true, deviceId: 'dev1' });
+
+      expect(await handleSettingsRoutes(req, mockRes, pathname, mockStore, mockSettingsFns)).toBe(true);
+      expect(mockSettingsFns.saveSettings).toHaveBeenCalledWith({
+        engineReasoningEfforts: { claude: 'high' },
+        engineServiceTiers: { codex: 'fast', opencode: null },
+      });
       const responseBody = JSON.parse((mockRes.end as any).mock.calls[0][0]);
       expect(responseBody.success).toBe(true);
     });
@@ -450,6 +472,32 @@ describe('auth-route-handlers', () => {
     it('PATCH rejects non-boolean for boolean settings', async () => {
       const pathname = '/api/settings/shared';
       const req = createMockReq(pathname, 'PATCH', { worktreeEnabled: 'yes' });
+      req.headers.authorization = 'Bearer valid-token';
+      mockStore.verifyToken.mockReturnValue({ valid: true, deviceId: 'dev1' });
+
+      expect(await handleSettingsRoutes(req, mockRes, pathname, mockStore, mockSettingsFns)).toBe(true);
+      expect(mockRes.writeHead).toHaveBeenCalledWith(400, expect.any(Object));
+      expect(mockSettingsFns.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it('PATCH rejects invalid reasoning effort values', async () => {
+      const pathname = '/api/settings/shared';
+      const req = createMockReq(pathname, 'PATCH', {
+        engineReasoningEfforts: { claude: 'turbo' },
+      });
+      req.headers.authorization = 'Bearer valid-token';
+      mockStore.verifyToken.mockReturnValue({ valid: true, deviceId: 'dev1' });
+
+      expect(await handleSettingsRoutes(req, mockRes, pathname, mockStore, mockSettingsFns)).toBe(true);
+      expect(mockRes.writeHead).toHaveBeenCalledWith(400, expect.any(Object));
+      expect(mockSettingsFns.saveSettings).not.toHaveBeenCalled();
+    });
+
+    it('PATCH rejects engineServiceTiers with prototype-pollution keys', async () => {
+      const pathname = '/api/settings/shared';
+      const req = createMockReq(pathname, 'PATCH', {
+        engineServiceTiers: { constructor: 'fast' },
+      });
       req.headers.authorization = 'Bearer valid-token';
       mockStore.verifyToken.mockReturnValue({ valid: true, deviceId: 'dev1' });
 

--- a/tests/unit/src/lib/settings.test.ts
+++ b/tests/unit/src/lib/settings.test.ts
@@ -156,6 +156,8 @@ describe('settings', () => {
             theme: 'dark',
             locale: 'zh',
             engineModels: { claude: { providerID: 'anthropic', modelID: 'sonnet' } },
+            engineReasoningEfforts: { claude: 'high' },
+            engineServiceTiers: { codex: 'fast', opencode: null },
           },
         }),
       });
@@ -167,6 +169,9 @@ describe('settings', () => {
       expect(getSetting('theme')).toBe('dark');
       expect(getSetting('locale')).toBe('zh');
       expect(getNestedSetting('engineModels.claude.modelID')).toBe('sonnet');
+      expect(getNestedSetting('engineReasoningEfforts.claude')).toBe('high');
+      expect(getNestedSetting('engineServiceTiers.codex')).toBe('fast');
+      expect(getNestedSetting('engineServiceTiers.opencode')).toBeNull();
     });
 
     it('does not overwrite existing localStorage on fetch failure', async () => {
@@ -214,6 +219,30 @@ describe('settings', () => {
           Authorization: 'Bearer test-token',
         },
         body: JSON.stringify({ theme: 'dark' }),
+      });
+    });
+
+    it('fires PATCH for shared nested keys by sending the root object', () => {
+      vi.mocked(Auth.isAuthenticated).mockReturnValue(true);
+
+      saveNestedSetting('engineReasoningEfforts.copilot', 'high');
+      expect(fetch).toHaveBeenNthCalledWith(1, '/api/settings/shared', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({ engineReasoningEfforts: { copilot: 'high' } }),
+      });
+
+      saveNestedSetting('engineServiceTiers.codex', null);
+      expect(fetch).toHaveBeenNthCalledWith(2, '/api/settings/shared', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer test-token',
+        },
+        body: JSON.stringify({ engineServiceTiers: { codex: null } }),
       });
     });
 


### PR DESCRIPTION
## Summary
- allow web clients to sync engine reasoning effort and service tier settings via shared settings
- add shared settings route coverage for these keys, including invalid input cases
- add renderer settings tests to verify nested shared settings PATCH back to the host

## Testing
- npm run typecheck
- npm run lint
- bun run test:unit
- npm run build