### PR TITLE
fix: prevent Enter key from triggering actions during IME composition

### DIFF
--- a/src/components/AddProjectModal.tsx
+++ b/src/components/AddProjectModal.tsx
@@ -42,7 +42,7 @@ export function AddProjectModal(props: AddProjectModalProps) {
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" && !loading()) {
+    if (e.key === "Enter" && !e.isComposing && !loading()) {
       handleAdd();
     } else if (e.key === "Escape") {
       props.onClose();

--- a/src/components/FileSearchBar.tsx
+++ b/src/components/FileSearchBar.tsx
@@ -140,7 +140,7 @@ export function FileSearchBar(props: FileSearchBarProps) {
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
       props.onClose();
-    } else if (e.key === "Enter") {
+    } else if (e.key === "Enter" && !e.isComposing) {
       if (e.shiftKey) goPrev();
       else goNext();
     }

--- a/src/components/InputAreaQuestion.tsx
+++ b/src/components/InputAreaQuestion.tsx
@@ -221,7 +221,7 @@ export function InputAreaQuestion(props: InputAreaQuestionProps) {
               value={customInputs()[pageIndex()] || ""}
               onInput={(e) => setCustomInput(e.currentTarget.value)}
               onKeyDown={(e) => {
-                if (e.key === "Enter" && hasAnyAnswer()) {
+                if (e.key === "Enter" && !e.isComposing && hasAnyAnswer()) {
                   e.preventDefault();
                   if (isLastPage()) {
                     handleSubmit();

--- a/src/components/SessionSidebar.tsx
+++ b/src/components/SessionSidebar.tsx
@@ -516,7 +516,7 @@ export function SessionSidebar(props: SessionSidebarProps) {
                   const cancelEditing = () => setEditingSessionId(null);
 
                   const handleKeyDown = (e: KeyboardEvent) => {
-                    if (e.key === "Enter") saveTitle();
+                    if (e.key === "Enter" && !e.isComposing) saveTitle();
                     else if (e.key === "Escape") cancelEditing();
                   };
 
@@ -881,7 +881,7 @@ export function SessionSidebar(props: SessionSidebarProps) {
                             const cancelEditing = () => setEditingSessionId(null);
 
                             const handleKeyDown = (e: KeyboardEvent) => {
-                              if (e.key === "Enter") saveTitle();
+                              if (e.key === "Enter" && !e.isComposing) saveTitle();
                               else if (e.key === "Escape") cancelEditing();
                             };
 
@@ -1248,7 +1248,7 @@ export function SessionSidebar(props: SessionSidebarProps) {
                           };
 
                           const handleKeyDown = (e: KeyboardEvent) => {
-                            if (e.key === "Enter") {
+                            if (e.key === "Enter" && !e.isComposing) {
                               saveTitle();
                             } else if (e.key === "Escape") {
                               cancelEditing();

--- a/src/pages/Devices.tsx
+++ b/src/pages/Devices.tsx
@@ -85,7 +85,7 @@ function DeviceCard(props: DeviceCardProps) {
                     class="px-2 py-1 text-sm border rounded dark:bg-slate-800 dark:border-slate-700"
                     placeholder={t().devices.renameDevicePlaceholder}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter") props.onConfirmRename();
+                      if (e.key === "Enter" && !e.isComposing) props.onConfirmRename();
                       if (e.key === "Escape") props.onCancelRename();
                     }}
                     autofocus


### PR DESCRIPTION
## Problem

When using IME input methods (Chinese, Japanese, Korean, etc.), pressing Enter to confirm a candidate word incorrectly triggers form submission or navigation actions. This affects all text inputs that listen for Enter key, not just the main prompt input (which was previously fixed).

## Fix


## Affected Components (7 locations, 5 files)

| File | Input | Action prevented |
|------|-------|-----------------|
| `InputAreaQuestion.tsx` | Question custom text input | Submit / next page |
| `Devices.tsx` | Device rename input | Confirm rename |
| `AddProjectModal.tsx` | Project path input | Confirm add |
| `SessionSidebar.tsx` ×3 | Session title editing (3 view modes) | Save title |
| `FileSearchBar.tsx` | File search input | Navigate matches |

## Notes

- Escape key handlers are intentionally left unchanged — Escape is not used during IME composition
- The main `PromptInput.tsx` already had this fix