### PR TITLE
fix(channels): session list visibility, grouping, and status notifications

### DIFF
--- a/electron/main/channels/dingtalk/dingtalk-adapter.ts
+++ b/electron/main/channels/dingtalk/dingtalk-adapter.ts
@@ -39,6 +39,8 @@ import {
   buildProjectListText,
   buildSessionListText,
   buildQuestionText,
+  buildSessionNotification,
+  groupAndSortSessions,
 } from "../shared/list-builders";
 import {
   handleSessionOpsCommand,
@@ -449,7 +451,25 @@ export class DingTalkAdapter extends ChannelAdapter {
       return;
     }
 
-    // 6. No project → show project list
+    // 6. No project → use default workspace as fallback
+    if (this.gatewayClient) {
+      const allProjects = await this.gatewayClient.listAllProjects();
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        if (this.sessionMapper.getTempSession(chatId)) {
+          await this.cleanupExpiredTempSession(chatId);
+        }
+        const defaultRef = {
+          directory: defaultProject.directory,
+          engineType: defaultProject.engineType,
+          projectId: defaultProject.id,
+        };
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        return;
+      }
+    }
+
+    // 7. Fallback: show project list
     await this.showProjectList(chatId);
   }
 
@@ -554,16 +574,27 @@ export class DingTalkAdapter extends ChannelAdapter {
   private async showProjectList(chatId: string): Promise<void> {
     if (!this.gatewayClient) return;
 
-    const projects = await this.gatewayClient.listAllProjects();
-    const text = buildProjectListText(projects);
-    await this.transport!.sendText(chatId, text);
+    const allProjects = await this.gatewayClient.listAllProjects();
+    const projects = allProjects.filter(p => !p.isDefault);
 
     if (projects.length > 0) {
+      await this.transport!.sendText(chatId, buildProjectListText(projects));
       const flatProjects = this.flattenProjectsByEngine(projects);
       this.sessionMapper.setPendingSelection(chatId, {
         type: "project",
         projects: flatProjects,
       });
+    } else {
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+      } else {
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+        this.sessionMapper.setPendingSelection(chatId, {
+          type: "project",
+          projects: [],
+        });
+      }
     }
   }
 
@@ -575,13 +606,14 @@ export class DingTalkAdapter extends ChannelAdapter {
   ): Promise<void> {
     if (!this.gatewayClient) return;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
-    const sessionText = buildSessionListText(filtered, projectName);
+    const filtered = sessions.filter((s) => s.projectId === project.projectId);
+    const sorted = groupAndSortSessions(filtered);
+    const sessionText = buildSessionListText(sorted, projectName);
     await this.transport!.sendText(chatId, sessionText);
 
     this.sessionMapper.setPendingSelection(chatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.projectId,
@@ -633,6 +665,7 @@ export class DingTalkAdapter extends ChannelAdapter {
     chatId: string,
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
+    projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -653,6 +686,8 @@ export class DingTalkAdapter extends ChannelAdapter {
       };
 
       this.sessionMapper.setTempSession(chatId, tempSession);
+      const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
+      await this.transport!.sendText(chatId, buildSessionNotification(name, session.engineType, session.id));
       await this.enqueueP2PMessage(chatId, text);
     } catch (err) {
       await this.transport!.sendText(
@@ -775,8 +810,14 @@ export class DingTalkAdapter extends ChannelAdapter {
     text: string,
     pending: DingTalkPendingSelection,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(chatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
-    if (isNaN(num) || num < 1 || !pending.projects || num > pending.projects.length) {
+    if (isNaN(num) || num < 1 || num > pending.projects.length) {
       return false;
     }
 

--- a/electron/main/channels/dingtalk/dingtalk-adapter.ts
+++ b/electron/main/channels/dingtalk/dingtalk-adapter.ts
@@ -810,8 +810,9 @@ export class DingTalkAdapter extends ChannelAdapter {
     text: string,
     pending: DingTalkPendingSelection,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
+      this.sessionMapper.clearPendingSelection(chatId);
       await this.showProjectList(chatId);
       return true;
     }

--- a/electron/main/channels/feishu/feishu-adapter.ts
+++ b/electron/main/channels/feishu/feishu-adapter.ts
@@ -1075,8 +1075,9 @@ export class FeishuAdapter extends ChannelAdapter {
     text: string,
     pending: import("./feishu-types").PendingSelection,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
+      this.sessionMapper.clearPendingSelection(chatId);
       await this.showProjectList(chatId);
       return true;
     }

--- a/electron/main/channels/feishu/feishu-adapter.ts
+++ b/electron/main/channels/feishu/feishu-adapter.ts
@@ -27,6 +27,8 @@ import {
   buildProjectListText,
   buildSessionListText,
   buildQuestionText,
+  buildSessionNotification,
+  groupAndSortSessions,
 } from "../shared/list-builders";
 import {
   handleSessionOpsCommand,
@@ -671,13 +673,16 @@ export class FeishuAdapter extends ChannelAdapter {
       const allProjects = await this.gatewayClient.listAllProjects();
       const defaultProject = allProjects.find(p => p.isDefault);
       if (defaultProject) {
+        // Cleanup expired temp session from a previous default-workspace round
+        if (this.sessionMapper.getTempSession(chatId)) {
+          await this.cleanupExpiredTempSession(chatId);
+        }
         const defaultRef = {
           directory: defaultProject.directory,
           engineType: defaultProject.engineType,
           projectId: defaultProject.id,
         };
-        this.sessionMapper.setP2PLastProject(chatId, defaultRef);
-        await this.createTempSessionAndSend(chatId, defaultRef, text);
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
         return;
       }
     }
@@ -801,19 +806,18 @@ export class FeishuAdapter extends ChannelAdapter {
         projects: flatProjects,
       });
     } else {
-      // No real projects — auto-use default workspace without showing empty list
+      // No real projects — show informational message.
+      // Do NOT set lastSelectedProject; let step 6 handle temp session creation
+      // when the user sends a natural-language message.
       const defaultProject = allProjects.find(p => p.isDefault);
       if (defaultProject) {
-        const defaultRef = {
-          directory: defaultProject.directory,
-          engineType: defaultProject.engineType,
-          projectId: defaultProject.id,
-        };
-        this.sessionMapper.setP2PLastProject(chatId, defaultRef);
+        await this.transport!.sendText(chatId, buildProjectListText([]));
       } else {
-        // No projects at all — show empty project list message
-        const text = buildProjectListText(projects);
-        await this.transport!.sendText(chatId, text);
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+        this.sessionMapper.setPendingSelection(chatId, {
+          type: "project",
+          projects: [],
+        });
       }
     }
   }
@@ -826,13 +830,14 @@ export class FeishuAdapter extends ChannelAdapter {
   ): Promise<void> {
     if (!this.gatewayClient) return;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
-    const sessionText = buildSessionListText(filtered, projectName);
+    const filtered = sessions.filter((s) => s.projectId === project.projectId);
+    const sorted = groupAndSortSessions(filtered);
+    const sessionText = buildSessionListText(sorted, projectName);
     await this.transport!.sendText(chatId, sessionText);
 
     this.sessionMapper.setPendingSelection(chatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.projectId,
@@ -909,6 +914,7 @@ export class FeishuAdapter extends ChannelAdapter {
     chatId: string,
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
+    projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -929,6 +935,8 @@ export class FeishuAdapter extends ChannelAdapter {
       };
 
       this.sessionMapper.setTempSession(chatId, tempSession);
+      const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
+      await this.transport!.sendText(chatId, buildSessionNotification(name, session.engineType, session.id));
       await this.enqueueP2PMessage(chatId, text);
     } catch (err) {
       await this.transport!.sendText(
@@ -1067,8 +1075,14 @@ export class FeishuAdapter extends ChannelAdapter {
     text: string,
     pending: import("./feishu-types").PendingSelection,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(chatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
-    if (isNaN(num) || num < 1 || !pending.projects || num > pending.projects.length) {
+    if (isNaN(num) || num < 1 || num > pending.projects.length) {
       return false; // Not a valid number — fall through to show project list again
     }
 

--- a/electron/main/channels/shared/list-builders.ts
+++ b/electron/main/channels/shared/list-builders.ts
@@ -12,7 +12,13 @@ import type {
 /** Build a numbered project list for text-based selection. */
 export function buildProjectListText(projects: UnifiedProject[]): string {
   if (projects.length === 0) {
-    return "📋 未找到项目。请先在 CodeMux 中启动一个会话。";
+    return [
+      "📋 暂无可用项目",
+      "─────────────────────────",
+      "请先在 CodeMux 桌面端打开项目目录并启动会话，之后即可在此渠道中使用。",
+      "",
+      "使用 /project 切换项目，/help 查看更多命令。",
+    ].join("\n");
   }
   const lines: string[] = ["📋 项目列表", "─────────────────────────"];
   for (let i = 0; i < projects.length; i++) {
@@ -25,8 +31,83 @@ export function buildProjectListText(projects: UnifiedProject[]): string {
   return lines.join("\n");
 }
 
+/** One-line session status notification for P2P channels. */
+export function buildSessionNotification(
+  projectName: string,
+  engineType: string,
+  sessionId: string,
+): string {
+  return `📋 ${projectName}（${engineType}）· ${sessionId.slice(0, 8)}`;
+}
+
+const SESSION_TITLE_MAX_LEN = 28;
+
+/** Truncate a session title to fit within the display width. */
+export function truncateTitle(title: string, maxLen = SESSION_TITLE_MAX_LEN): string {
+  return title.length > maxLen ? title.slice(0, maxLen) + "…" : title;
+}
+
+/** Return a Chinese relative-time string for the given timestamp. */
+export function relativeTimeZh(timestamp: number): string {
+  const diff = Date.now() - timestamp;
+  if (diff < 60_000) return "刚刚";
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}分钟前`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}小时前`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}天前`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}周前`;
+  const months = Math.floor(days / 30);
+  return `${months}月前`;
+}
+
 /**
- * Build a numbered session list for text-based selection. Top 9 by recency.
+ * Group and sort sessions for display:
+ *   1. Normal sessions (no worktreeId) sorted by recency
+ *   2. Worktree groups, each sorted by recency, groups ordered by most-recent session
+ *
+ * The returned array order matches the numbered display order.
+ */
+export function groupAndSortSessions(sessions: UnifiedSession[]): UnifiedSession[] {
+  const byRecency = (a: UnifiedSession, b: UnifiedSession) =>
+    (b.time?.updated ?? 0) - (a.time?.updated ?? 0);
+
+  const normal = sessions.filter((s) => !s.worktreeId).sort(byRecency);
+
+  // Group worktree sessions by worktreeId
+  const wtGroups = new Map<string, UnifiedSession[]>();
+  for (const s of sessions) {
+    if (!s.worktreeId) continue;
+    let group = wtGroups.get(s.worktreeId);
+    if (!group) {
+      group = [];
+      wtGroups.set(s.worktreeId, group);
+    }
+    group.push(s);
+  }
+
+  // Sort each group internally, then sort groups by most-recent session
+  const sortedGroups = [...wtGroups.entries()]
+    .map(([id, group]) => ({ id, sessions: group.sort(byRecency) }))
+    .sort((a, b) => (b.sessions[0].time?.updated ?? 0) - (a.sessions[0].time?.updated ?? 0));
+
+  const result = [...normal];
+  for (const g of sortedGroups) {
+    result.push(...g.sessions);
+  }
+  return result;
+}
+
+/**
+ * Build a numbered session list for text-based selection.
+ *
+ * Expects sessions pre-sorted by `groupAndSortSessions` — the array order
+ * determines the numbering and must match what is stored in pendingSelection.
+ *
+ * Worktree sessions are visually grouped: when a new `worktreeId` is
+ * encountered, a `🌿 {worktreeId}` section header is inserted.
  *
  * `newHint` controls how to instruct the user to create a new session:
  *   - default ("/new"): show "使用 /new 创建新会话" — the cross-channel norm
@@ -50,16 +131,24 @@ export function buildSessionListText(
   ];
 
   if (sessions.length > 0) {
-    lines.push("已有会话：");
-    const sorted = [...sessions].sort(
-      (a, b) => (b.time?.updated ?? 0) - (a.time?.updated ?? 0),
-    );
-    const limited = sorted.slice(0, 9);
-    for (let i = 0; i < limited.length; i++) {
-      const s = limited[i];
-      const title = s.title || `Session ${s.id.slice(0, 8)}`;
+    let currentWorktreeId: string | undefined;
+
+    for (let i = 0; i < sessions.length; i++) {
+      const s = sessions[i];
+
+      // Insert worktree group header on transition
+      if (s.worktreeId !== currentWorktreeId) {
+        if (s.worktreeId) {
+          lines.push("");
+          lines.push(`🌿 ${s.worktreeId}`);
+        }
+        currentWorktreeId = s.worktreeId;
+      }
+
+      const title = truncateTitle(s.title || `Session ${s.id.slice(0, 8)}`);
       const engineLabel = s.engineType ? ` [${s.engineType}]` : "";
-      lines.push(`  ${i + 1}. ${title}${engineLabel}`);
+      const timeLabel = s.time?.updated ? ` (${relativeTimeZh(s.time.updated)})` : "";
+      lines.push(`  ${i + 1}. ${title}${engineLabel}${timeLabel}`);
     }
     lines.push("─────────────────────────");
     lines.push(`回复数字以打开会话，或${createHint}。`);

--- a/electron/main/channels/teams/teams-adapter.ts
+++ b/electron/main/channels/teams/teams-adapter.ts
@@ -40,6 +40,8 @@ import {
   buildProjectListText,
   buildSessionListText,
   buildQuestionText,
+  buildSessionNotification,
+  groupAndSortSessions,
 } from "../shared/list-builders";
 import {
   handleSessionOpsCommand,
@@ -625,7 +627,25 @@ export class TeamsAdapter extends ChannelAdapter {
       return;
     }
 
-    // 6. No project → show project list
+    // 6. No project → use default workspace as fallback
+    if (this.gatewayClient) {
+      const allProjects = await this.gatewayClient.listAllProjects();
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        if (this.sessionMapper.getTempSession(chatId)) {
+          await this.cleanupExpiredTempSession(chatId);
+        }
+        const defaultRef = {
+          directory: defaultProject.directory,
+          engineType: defaultProject.engineType,
+          projectId: defaultProject.id,
+        };
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        return;
+      }
+    }
+
+    // 7. Fallback: show project list
     await this.showProjectList(chatId);
   }
 
@@ -726,16 +746,27 @@ export class TeamsAdapter extends ChannelAdapter {
   private async showProjectList(chatId: string): Promise<void> {
     if (!this.gatewayClient) return;
 
-    const projects = await this.gatewayClient.listAllProjects();
-    const text = buildProjectListText(projects);
-    await this.transport!.sendText(chatId, text);
+    const allProjects = await this.gatewayClient.listAllProjects();
+    const projects = allProjects.filter(p => !p.isDefault);
 
     if (projects.length > 0) {
+      await this.transport!.sendText(chatId, buildProjectListText(projects));
       const flatProjects = this.flattenProjectsByEngine(projects);
       this.sessionMapper.setPendingSelection(chatId, {
         type: "project",
         projects: flatProjects,
       });
+    } else {
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+      } else {
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+        this.sessionMapper.setPendingSelection(chatId, {
+          type: "project",
+          projects: [],
+        });
+      }
     }
   }
 
@@ -751,13 +782,14 @@ export class TeamsAdapter extends ChannelAdapter {
   ): Promise<void> {
     if (!this.gatewayClient) return;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
-    const sessionText = buildSessionListText(filtered, projectName);
+    const filtered = sessions.filter((s) => s.projectId === project.projectId);
+    const sorted = groupAndSortSessions(filtered);
+    const sessionText = buildSessionListText(sorted, projectName);
     await this.transport!.sendText(chatId, sessionText);
 
     this.sessionMapper.setPendingSelection(chatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.projectId,
@@ -796,7 +828,7 @@ export class TeamsAdapter extends ChannelAdapter {
 
       await this.transport!.sendText(
         chatId,
-        `📋 已创建会话：${projectName}\n发送消息即可开始对话。`,
+        buildSessionNotification(projectName, session.engineType, session.id),
       );
     } catch (err) {
       await this.transport!.sendText(
@@ -824,6 +856,7 @@ export class TeamsAdapter extends ChannelAdapter {
       projectId: string;
     },
     text: string,
+    projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -844,6 +877,8 @@ export class TeamsAdapter extends ChannelAdapter {
       };
 
       this.sessionMapper.setTempSession(chatId, tempSession);
+      const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
+      await this.transport!.sendText(chatId, buildSessionNotification(name, session.engineType, session.id));
       await this.enqueueP2PMessage(chatId, text);
     } catch (err) {
       await this.transport!.sendText(
@@ -984,11 +1019,16 @@ export class TeamsAdapter extends ChannelAdapter {
     text: string,
     pending: TeamsPendingSelection,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(chatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
     if (
       isNaN(num) ||
       num < 1 ||
-      !pending.projects ||
       num > pending.projects.length
     ) {
       return false;
@@ -1045,9 +1085,10 @@ export class TeamsAdapter extends ChannelAdapter {
     };
 
     this.sessionMapper.setTempSession(chatId, tempSession);
+    const projectName = pending.projectName || pending.directory?.split(/[\\/]/).pop() || "";
     await this.transport!.sendText(
       chatId,
-      `📋 已切换到会话：${session.title || session.id.slice(0, 8)}\n发送消息即可继续对话。`,
+      buildSessionNotification(projectName, session.engineType, session.id),
     );
     return true;
   }
@@ -1172,11 +1213,16 @@ export class TeamsAdapter extends ChannelAdapter {
     pending: TeamsPendingSelection,
     serviceUrl: string,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(groupChatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
     if (
       isNaN(num) ||
       num < 1 ||
-      !pending.projects ||
       num > pending.projects.length
     ) {
       return false;
@@ -1191,17 +1237,18 @@ export class TeamsAdapter extends ChannelAdapter {
     // Show session list for group binding
     if (!this.gatewayClient) return false;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
+    const filtered = sessions.filter((s) => s.projectId === project.id);
+    const sorted = groupAndSortSessions(filtered);
     // Group-bind flow keeps the legacy "new" keyword: /new isn't a group command,
     // so this is the only way to create a session for the binding.
-    const sessionText = buildSessionListText(filtered, projectName, {
+    const sessionText = buildSessionListText(sorted, projectName, {
       newHint: "keyword",
     });
     await this.transport!.sendText(groupChatId, sessionText);
 
     this.sessionMapper.setPendingSelection(groupChatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.id,

--- a/electron/main/channels/teams/teams-adapter.ts
+++ b/electron/main/channels/teams/teams-adapter.ts
@@ -1019,8 +1019,9 @@ export class TeamsAdapter extends ChannelAdapter {
     text: string,
     pending: TeamsPendingSelection,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
+      this.sessionMapper.clearPendingSelection(chatId);
       await this.showProjectList(chatId);
       return true;
     }
@@ -1213,9 +1214,10 @@ export class TeamsAdapter extends ChannelAdapter {
     pending: TeamsPendingSelection,
     serviceUrl: string,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
-      await this.showProjectList(groupChatId);
+      this.sessionMapper.clearPendingSelection(groupChatId);
+      await this.showGroupProjectList(groupChatId, serviceUrl);
       return true;
     }
 

--- a/electron/main/channels/telegram/telegram-adapter.ts
+++ b/electron/main/channels/telegram/telegram-adapter.ts
@@ -1004,8 +1004,9 @@ export class TelegramAdapter extends ChannelAdapter {
     text: string,
     pending: TelegramPendingSelection,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
+      this.sessionMapper.clearPendingSelection(chatId);
       await this.showProjectList(chatId);
       return true;
     }

--- a/electron/main/channels/telegram/telegram-adapter.ts
+++ b/electron/main/channels/telegram/telegram-adapter.ts
@@ -38,6 +38,8 @@ import {
   buildProjectListText,
   buildSessionListText,
   buildQuestionText,
+  buildSessionNotification,
+  groupAndSortSessions,
 } from "../shared/list-builders";
 import { handleSessionOpsCommand, type SessionContext } from "../shared/session-commands";
 import {
@@ -637,7 +639,25 @@ export class TelegramAdapter extends ChannelAdapter {
       return;
     }
 
-    // 6. No project → show project list
+    // 6. No project → use default workspace as fallback
+    if (this.gatewayClient) {
+      const allProjects = await this.gatewayClient.listAllProjects();
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        if (this.sessionMapper.getTempSession(chatId)) {
+          await this.cleanupExpiredTempSession(chatId);
+        }
+        const defaultRef = {
+          directory: defaultProject.directory,
+          engineType: defaultProject.engineType,
+          projectId: defaultProject.id,
+        };
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        return;
+      }
+    }
+
+    // 7. Fallback: show project list
     await this.showProjectList(chatId);
   }
 
@@ -733,16 +753,27 @@ export class TelegramAdapter extends ChannelAdapter {
   private async showProjectList(chatId: string): Promise<void> {
     if (!this.gatewayClient) return;
 
-    const projects = await this.gatewayClient.listAllProjects();
-    const text = buildProjectListText(projects);
-    await this.transport!.sendText(chatId, text);
+    const allProjects = await this.gatewayClient.listAllProjects();
+    const projects = allProjects.filter(p => !p.isDefault);
 
     if (projects.length > 0) {
+      await this.transport!.sendText(chatId, buildProjectListText(projects));
       const flatProjects = this.flattenProjectsByEngine(projects);
       this.sessionMapper.setPendingSelection(chatId, {
         type: "project",
         projects: flatProjects,
       });
+    } else {
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+      } else {
+        await this.transport!.sendText(chatId, buildProjectListText([]));
+        this.sessionMapper.setPendingSelection(chatId, {
+          type: "project",
+          projects: [],
+        });
+      }
     }
   }
 
@@ -754,13 +785,14 @@ export class TelegramAdapter extends ChannelAdapter {
   ): Promise<void> {
     if (!this.gatewayClient) return;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
-    const sessionText = buildSessionListText(filtered, projectName);
+    const filtered = sessions.filter((s) => s.projectId === project.projectId);
+    const sorted = groupAndSortSessions(filtered);
+    const sessionText = buildSessionListText(sorted, projectName);
     await this.transport!.sendText(chatId, sessionText);
 
     this.sessionMapper.setPendingSelection(chatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.projectId,
@@ -795,7 +827,7 @@ export class TelegramAdapter extends ChannelAdapter {
 
       await this.transport!.sendText(
         chatId,
-        `📋 已创建会话：${projectName}\n发送消息即可开始对话。`,
+        buildSessionNotification(projectName, session.engineType, session.id),
       );
     } catch (err) {
       await this.transport!.sendText(
@@ -819,6 +851,7 @@ export class TelegramAdapter extends ChannelAdapter {
     chatId: string,
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
+    projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -839,6 +872,10 @@ export class TelegramAdapter extends ChannelAdapter {
       };
 
       this.sessionMapper.setTempSession(chatId, tempSession);
+
+      const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
+      await this.transport!.sendText(chatId, buildSessionNotification(name, session.engineType, session.id));
+
       await this.enqueueP2PMessage(chatId, text);
     } catch (err) {
       await this.transport!.sendText(
@@ -967,8 +1004,14 @@ export class TelegramAdapter extends ChannelAdapter {
     text: string,
     pending: TelegramPendingSelection,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(chatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
-    if (isNaN(num) || num < 1 || !pending.projects || num > pending.projects.length) {
+    if (isNaN(num) || num < 1 || num > pending.projects.length) {
       return false;
     }
 
@@ -1017,9 +1060,10 @@ export class TelegramAdapter extends ChannelAdapter {
     };
 
     this.sessionMapper.setTempSession(chatId, tempSession);
+    const projectName = pending.projectName || pending.directory?.split(/[\\/]/).pop() || "";
     await this.transport!.sendText(
       chatId,
-      `📋 已切换到会话：${session.title || session.id.slice(0, 8)}\n发送消息即可继续对话。`,
+      buildSessionNotification(projectName, session.engineType, session.id),
     );
     return true;
   }

--- a/electron/main/channels/wecom/wecom-adapter.ts
+++ b/electron/main/channels/wecom/wecom-adapter.ts
@@ -765,8 +765,9 @@ export class WeComAdapter extends ChannelAdapter {
     text: string,
     pending: BasePendingSelection,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
+      this.sessionMapper.clearPendingSelection(chatId);
       await this.showProjectList(chatId);
       return true;
     }

--- a/electron/main/channels/wecom/wecom-adapter.ts
+++ b/electron/main/channels/wecom/wecom-adapter.ts
@@ -37,6 +37,8 @@ import {
   buildProjectListText,
   buildSessionListText,
   buildQuestionText,
+  buildSessionNotification,
+  groupAndSortSessions,
 } from "../shared/list-builders";
 import { handleSessionOpsCommand, type SessionContext } from "../shared/session-commands";
 import {
@@ -545,7 +547,25 @@ export class WeComAdapter extends ChannelAdapter {
       return;
     }
 
-    // 6. No project → show project list
+    // 6. No project → use default workspace as fallback
+    if (this.gatewayClient) {
+      const allProjects = await this.gatewayClient.listAllProjects();
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        if (this.sessionMapper.getTempSession(chatId)) {
+          await this.cleanupExpiredTempSession(chatId);
+        }
+        const defaultRef = {
+          directory: defaultProject.directory,
+          engineType: defaultProject.engineType,
+          projectId: defaultProject.id,
+        };
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        return;
+      }
+    }
+
+    // 7. Fallback: show project list
     await this.showProjectList(chatId);
   }
 
@@ -640,16 +660,27 @@ export class WeComAdapter extends ChannelAdapter {
   private async showProjectList(chatId: string): Promise<void> {
     if (!this.gatewayClient || !this.transport) return;
 
-    const projects = await this.gatewayClient.listAllProjects();
-    const text = buildProjectListText(projects);
-    await this.transport.sendText(chatId, text);
+    const allProjects = await this.gatewayClient.listAllProjects();
+    const projects = allProjects.filter(p => !p.isDefault);
 
     if (projects.length > 0) {
+      await this.transport.sendText(chatId, buildProjectListText(projects));
       const flatProjects = this.flattenProjectsByEngine(projects);
       this.sessionMapper.setPendingSelection(chatId, {
         type: "project",
         projects: flatProjects,
       });
+    } else {
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        await this.transport.sendText(chatId, buildProjectListText([]));
+      } else {
+        await this.transport.sendText(chatId, buildProjectListText([]));
+        this.sessionMapper.setPendingSelection(chatId, {
+          type: "project",
+          projects: [],
+        });
+      }
     }
   }
 
@@ -660,13 +691,14 @@ export class WeComAdapter extends ChannelAdapter {
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport) return;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
-    const sessionText = buildSessionListText(filtered, projectName);
+    const filtered = sessions.filter((s) => s.projectId === project.projectId);
+    const sorted = groupAndSortSessions(filtered);
+    const sessionText = buildSessionListText(sorted, projectName);
     await this.transport.sendText(chatId, sessionText);
 
     this.sessionMapper.setPendingSelection(chatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.projectId,
@@ -703,7 +735,7 @@ export class WeComAdapter extends ChannelAdapter {
 
       await this.transport.sendText(
         chatId,
-        `✅ 已创建新会话 [${projectName}]\n直接发送消息即可开始对话。`,
+        buildSessionNotification(projectName, session.engineType, session.id),
       );
     } catch (err) {
       await this.transport.sendText(
@@ -733,8 +765,14 @@ export class WeComAdapter extends ChannelAdapter {
     text: string,
     pending: BasePendingSelection,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(chatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
-    if (isNaN(num) || num < 1 || !pending.projects || num > pending.projects.length) {
+    if (isNaN(num) || num < 1 || num > pending.projects.length) {
       return false;
     }
 
@@ -794,9 +832,10 @@ export class WeComAdapter extends ChannelAdapter {
     };
     this.sessionMapper.setTempSession(chatId, tempSession);
 
+    const projectName = pending.projectName || pending.directory?.split(/[\\/]/).pop() || "";
     await this.transport!.sendText(
       chatId,
-      `✅ 已切换到会话 [${pending.projectName || session.id}]\n直接发送消息即可继续对话。`,
+      buildSessionNotification(projectName, session.engineType, session.id),
     );
 
     return true;
@@ -814,6 +853,7 @@ export class WeComAdapter extends ChannelAdapter {
     chatId: string,
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
+    projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -834,6 +874,10 @@ export class WeComAdapter extends ChannelAdapter {
       };
 
       this.sessionMapper.setTempSession(chatId, tempSession);
+
+      const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
+      await this.transport!.sendText(chatId, buildSessionNotification(name, session.engineType, session.id));
+
       await this.enqueueP2PMessage(chatId, text);
     } catch (err) {
       await this.transport!.sendText(

--- a/electron/main/channels/weixin-ilink/weixin-ilink-adapter.ts
+++ b/electron/main/channels/weixin-ilink/weixin-ilink-adapter.ts
@@ -32,6 +32,8 @@ import {
   buildProjectListText,
   buildSessionListText,
   buildQuestionText,
+  buildSessionNotification,
+  groupAndSortSessions,
 } from "../shared/list-builders";
 import { handleSessionOpsCommand, type SessionContext } from "../shared/session-commands";
 import {
@@ -515,6 +517,25 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
       return;
     }
 
+    // 6. No project → use default workspace as fallback
+    if (this.gatewayClient) {
+      const allProjects = await this.gatewayClient.listAllProjects();
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        if (this.sessionMapper.getTempSession(chatId)) {
+          await this.cleanupExpiredTempSession(chatId);
+        }
+        const defaultRef = {
+          directory: defaultProject.directory,
+          engineType: defaultProject.engineType,
+          projectId: defaultProject.id,
+        };
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        return;
+      }
+    }
+
+    // 7. Fallback: show project list
     await this.showProjectList(chatId);
   }
 
@@ -610,13 +631,27 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
 
   private async showProjectList(chatId: string): Promise<void> {
     if (!this.gatewayClient || !this.transport) return;
-    const projects = await this.gatewayClient.listAllProjects();
-    await this.transport.sendText(chatId, buildProjectListText(projects));
+
+    const allProjects = await this.gatewayClient.listAllProjects();
+    const projects = allProjects.filter(p => !p.isDefault);
+
     if (projects.length > 0) {
+      await this.transport.sendText(chatId, buildProjectListText(projects));
       this.sessionMapper.setPendingSelection(chatId, {
         type: "project",
         projects,
       });
+    } else {
+      const defaultProject = allProjects.find(p => p.isDefault);
+      if (defaultProject) {
+        await this.transport.sendText(chatId, buildProjectListText([]));
+      } else {
+        await this.transport.sendText(chatId, buildProjectListText([]));
+        this.sessionMapper.setPendingSelection(chatId, {
+          type: "project",
+          projects: [],
+        });
+      }
     }
   }
 
@@ -627,11 +662,12 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport) return;
     const sessions = await this.gatewayClient.listAllSessions();
-    const filtered = sessions.filter((s) => s.directory === project.directory);
-    await this.transport.sendText(chatId, buildSessionListText(filtered, projectName));
+    const filtered = sessions.filter((s) => s.projectId === project.projectId);
+    const sorted = groupAndSortSessions(filtered);
+    await this.transport.sendText(chatId, buildSessionListText(sorted, projectName));
     this.sessionMapper.setPendingSelection(chatId, {
       type: "session",
-      sessions: filtered,
+      sessions: sorted,
       engineType: project.engineType,
       directory: project.directory,
       projectId: project.projectId,
@@ -664,7 +700,7 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
       this.sessionMapper.setTempSession(chatId, tempSession);
       await this.transport.sendText(
         chatId,
-        `📋 已创建会话：${projectName}\n发送消息即可开始对话。`,
+        buildSessionNotification(projectName, session.engineType, session.id),
       );
     } catch (err) {
       await this.transport.sendText(
@@ -689,8 +725,14 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
     text: string,
     pending: WeixinIlinkPendingSelection,
   ): Promise<boolean> {
+    // Empty project list — re-fetch to check if projects are now available
+    if (!pending.projects || pending.projects.length === 0) {
+      await this.showProjectList(chatId);
+      return true;
+    }
+
     const num = parseInt(text.trim(), 10);
-    if (isNaN(num) || num < 1 || !pending.projects || num > pending.projects.length) {
+    if (isNaN(num) || num < 1 || num > pending.projects.length) {
       return false;
     }
     const project = pending.projects[num - 1];
@@ -735,7 +777,7 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
     this.sessionMapper.setTempSession(chatId, tempSession);
     await this.transport.sendText(
       chatId,
-      `📋 已切换到会话：${session.title || session.id.slice(0, 8)}\n发送消息即可继续对话。`,
+      buildSessionNotification(pending.projectName || pending.directory || "unknown", session.engineType, session.id),
     );
     return true;
   }
@@ -752,6 +794,7 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
     chatId: string,
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
+    projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport) return;
 
@@ -770,6 +813,8 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
         processing: false,
       };
       this.sessionMapper.setTempSession(chatId, tempSession);
+      const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
+      await this.transport.sendText(chatId, buildSessionNotification(name, session.engineType, session.id));
       await this.enqueueP2PMessage(chatId, text);
     } catch (err) {
       await this.transport.sendText(

--- a/electron/main/channels/weixin-ilink/weixin-ilink-adapter.ts
+++ b/electron/main/channels/weixin-ilink/weixin-ilink-adapter.ts
@@ -725,8 +725,9 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
     text: string,
     pending: WeixinIlinkPendingSelection,
   ): Promise<boolean> {
-    // Empty project list — re-fetch to check if projects are now available
+    // Empty project list — clear stale pending state before re-fetching
     if (!pending.projects || pending.projects.length === 0) {
+      this.sessionMapper.clearPendingSelection(chatId);
       await this.showProjectList(chatId);
       return true;
     }

--- a/tests/unit/electron/channels/dingtalk/dingtalk-adapter.test.ts
+++ b/tests/unit/electron/channels/dingtalk/dingtalk-adapter.test.ts
@@ -429,7 +429,7 @@ describe("DingTalkAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = { listAllProjects: vi.fn(async () => []) };
       await a.showProjectList("c1");
-      expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
+      expect(a.sessionMapper.getPendingSelection("c1")).toEqual({ type: "project", projects: [] });
     });
 
     it("showSessionListForProject filters by directory and stores pending", async () => {
@@ -437,8 +437,8 @@ describe("DingTalkAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = {
         listAllSessions: vi.fn(async () => [
-          { id: "s1", directory: "/a", engineType: "claude", title: "x" },
-          { id: "s2", directory: "/b", engineType: "claude", title: "y" },
+          { id: "s1", directory: "/a", engineType: "claude", title: "x", projectId: "p" },
+          { id: "s2", directory: "/b", engineType: "claude", title: "y", projectId: "other" },
         ]),
       };
       await a.showSessionListForProject(

--- a/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
@@ -621,7 +621,7 @@ describe("FeishuAdapter", () => {
       };
       a.sessionMapper.getOrCreateP2PChat("c1", "u1");
       await a.showProjectList("c1");
-      expect(a.sessionMapper.getP2PChat("c1")?.lastSelectedProject?.projectId).toBe("def");
+      expect(a.sessionMapper.getP2PChat("c1")?.lastSelectedProject).toBeUndefined();
     });
 
     it("showProjectList sends empty list message when no projects at all", async () => {
@@ -637,8 +637,8 @@ describe("FeishuAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = {
         listAllSessions: vi.fn(async () => [
-          { id: "s1", directory: "/a", engineType: "claude", title: "x" },
-          { id: "s2", directory: "/b", engineType: "claude", title: "y" },
+          { id: "s1", directory: "/a", engineType: "claude", title: "x", projectId: "p" },
+          { id: "s2", directory: "/b", engineType: "claude", title: "y", projectId: "other" },
         ]),
       };
       a.sessionMapper.getOrCreateP2PChat("c1", "u1");

--- a/tests/unit/electron/channels/shared/command-parser.test.ts
+++ b/tests/unit/electron/channels/shared/command-parser.test.ts
@@ -12,6 +12,10 @@ import {
   buildSessionListText,
   buildQuestionText,
   buildHistoryEntries,
+  buildSessionNotification,
+  relativeTimeZh,
+  truncateTitle,
+  groupAndSortSessions,
 } from "../../../../../electron/main/channels/shared/list-builders";
 
 describe("shared command parser", () => {
@@ -93,8 +97,19 @@ describe("shared help-text builder", () => {
 });
 
 describe("shared list builders", () => {
-  it("renders empty project list", () => {
-    expect(buildProjectListText([])).toContain("未找到项目");
+  it("renders empty project list with default workspace guidance", () => {
+    const text = buildProjectListText([]);
+    expect(text).toContain("暂无可用项目");
+    expect(text).toContain("桌面端");
+    expect(text).toContain("/help");
+  });
+
+  it("buildSessionNotification shows project name, engine type, and short session ID", () => {
+    const text = buildSessionNotification("codemux", "claude", "abc12345-6789-0000");
+    expect(text).toContain("codemux");
+    expect(text).toContain("claude");
+    expect(text).toContain("abc12345");
+    expect(text).not.toContain("6789-0000");
   });
 
   it("renders numbered project list", () => {
@@ -107,8 +122,9 @@ describe("shared list builders", () => {
   });
 
   it("renders session list with /new hint by default", () => {
+    const now = Date.now();
     const text = buildSessionListText(
-      [{ id: "s1", title: "Existing", time: { updated: 100 } } as any],
+      [{ id: "s1", title: "Existing", time: { updated: now } } as any],
       "myproj",
     );
     expect(text).toContain("myproj");
@@ -177,23 +193,23 @@ describe("shared list builders", () => {
     expect(entries[0].text).toBe(exact);
   });
 
-  it("buildSessionListText sorts by updated DESC and limits to 9", () => {
+  it("buildSessionListText shows all sessions without limit", () => {
+    const now = Date.now();
     const sessions = Array.from({ length: 12 }, (_, i) => ({
       id: `s${i}`,
       title: `T${i}`,
-      time: { updated: i * 100 },
+      time: { updated: now - i * 100_000 },
     })) as any[];
+    // Sessions are pre-sorted (caller's responsibility via groupAndSortSessions)
     const text = buildSessionListText(sessions, "proj");
-    // The most recent (T11) should be first, T3 should be the 9th (last shown)
-    expect(text).toContain("1. T11");
-    expect(text).toContain("9. T3");
-    expect(text).not.toContain("T2");
-    expect(text).not.toContain("T0");
+    // All 12 sessions should be visible
+    expect(text).toContain("1. T0");
+    expect(text).toContain("12. T11");
   });
 
   it("buildSessionListText falls back to id-prefix title when missing", () => {
     const text = buildSessionListText(
-      [{ id: "abcdef0123456789", time: { updated: 1 } } as any],
+      [{ id: "abcdef0123456789", time: { updated: Date.now() } } as any],
       "proj",
     );
     expect(text).toContain("Session abcdef01");
@@ -201,7 +217,7 @@ describe("shared list builders", () => {
 
   it("buildSessionListText appends [engineType] when present", () => {
     const text = buildSessionListText(
-      [{ id: "x", title: "Hello", engineType: "claude", time: { updated: 1 } } as any],
+      [{ id: "x", title: "Hello", engineType: "claude", time: { updated: Date.now() } } as any],
       "proj",
     );
     expect(text).toContain("Hello [claude]");
@@ -242,5 +258,148 @@ describe("shared list builders", () => {
     const text = buildQuestionText("Just FYI", []);
     expect(text).toContain("Just FYI");
     expect(text).not.toMatch(/^\s+1\./m);
+  });
+
+  it("buildSessionListText displays relative time", () => {
+    const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
+    const text = buildSessionListText(
+      [{ id: "s1", title: "Task", time: { updated: twoHoursAgo } } as any],
+      "proj",
+    );
+    expect(text).toContain("(2小时前)");
+  });
+
+  it("buildSessionListText truncates long titles", () => {
+    const longTitle = "A".repeat(40);
+    const text = buildSessionListText(
+      [{ id: "s1", title: longTitle, time: { updated: Date.now() } } as any],
+      "proj",
+    );
+    expect(text).toContain("A".repeat(28) + "…");
+    expect(text).not.toContain(longTitle);
+  });
+
+  it("buildSessionListText groups worktree sessions by worktreeId", () => {
+    const now = Date.now();
+    const sessions = [
+      { id: "n1", title: "Normal 1", time: { updated: now } },
+      { id: "n2", title: "Normal 2", time: { updated: now - 1000 } },
+      { id: "w1", title: "WT Task 1", worktreeId: "fix-ci", time: { updated: now - 2000 } },
+      { id: "w2", title: "WT Task 2", worktreeId: "fix-ci", time: { updated: now - 3000 } },
+      { id: "w3", title: "WT Task 3", worktreeId: "feat-login", time: { updated: now - 4000 } },
+    ] as any[];
+    const text = buildSessionListText(sessions, "proj");
+    // Normal sessions first
+    expect(text).toContain("1. Normal 1");
+    expect(text).toContain("2. Normal 2");
+    // Worktree group headers
+    expect(text).toContain("🌿 fix-ci");
+    expect(text).toContain("🌿 feat-login");
+    // Numbering continues across groups
+    expect(text).toContain("3. WT Task 1");
+    expect(text).toContain("4. WT Task 2");
+    expect(text).toContain("5. WT Task 3");
+    // Group header comes before its sessions
+    const fixCiPos = text.indexOf("🌿 fix-ci");
+    const wtTask1Pos = text.indexOf("3. WT Task 1");
+    expect(fixCiPos).toBeLessThan(wtTask1Pos);
+  });
+
+  it("buildSessionListText omits worktree header when no worktree sessions", () => {
+    const text = buildSessionListText(
+      [{ id: "n1", title: "Normal", time: { updated: Date.now() } } as any],
+      "proj",
+    );
+    expect(text).not.toContain("🌿");
+  });
+});
+
+describe("relativeTimeZh", () => {
+  it("returns 刚刚 for recent timestamps", () => {
+    expect(relativeTimeZh(Date.now())).toBe("刚刚");
+    expect(relativeTimeZh(Date.now() - 30_000)).toBe("刚刚");
+  });
+
+  it("returns minutes for 1-59 minutes", () => {
+    expect(relativeTimeZh(Date.now() - 5 * 60_000)).toBe("5分钟前");
+    expect(relativeTimeZh(Date.now() - 59 * 60_000)).toBe("59分钟前");
+  });
+
+  it("returns hours for 1-23 hours", () => {
+    expect(relativeTimeZh(Date.now() - 2 * 3600_000)).toBe("2小时前");
+    expect(relativeTimeZh(Date.now() - 23 * 3600_000)).toBe("23小时前");
+  });
+
+  it("returns days for 1-6 days", () => {
+    expect(relativeTimeZh(Date.now() - 3 * 86400_000)).toBe("3天前");
+  });
+
+  it("returns weeks for 1-4 weeks", () => {
+    expect(relativeTimeZh(Date.now() - 14 * 86400_000)).toBe("2周前");
+  });
+
+  it("returns months for 5+ weeks", () => {
+    expect(relativeTimeZh(Date.now() - 60 * 86400_000)).toBe("2月前");
+  });
+});
+
+describe("truncateTitle", () => {
+  it("returns title as-is when within limit", () => {
+    expect(truncateTitle("short")).toBe("short");
+  });
+
+  it("returns title as-is when exactly at limit", () => {
+    const exact = "A".repeat(28);
+    expect(truncateTitle(exact)).toBe(exact);
+  });
+
+  it("truncates and adds ellipsis when over limit", () => {
+    const long = "A".repeat(40);
+    expect(truncateTitle(long)).toBe("A".repeat(28) + "…");
+  });
+
+  it("respects custom maxLen", () => {
+    expect(truncateTitle("abcdefgh", 5)).toBe("abcde…");
+  });
+});
+
+describe("groupAndSortSessions", () => {
+  it("places normal sessions before worktree sessions", () => {
+    const now = Date.now();
+    const sessions = [
+      { id: "w1", worktreeId: "wt", time: { updated: now } },
+      { id: "n1", time: { updated: now - 1000 } },
+    ] as any[];
+    const result = groupAndSortSessions(sessions);
+    expect(result[0].id).toBe("n1");
+    expect(result[1].id).toBe("w1");
+  });
+
+  it("sorts each group by recency (most recent first)", () => {
+    const now = Date.now();
+    const sessions = [
+      { id: "n1", time: { updated: now - 2000 } },
+      { id: "n2", time: { updated: now } },
+      { id: "w1", worktreeId: "wt", time: { updated: now - 3000 } },
+      { id: "w2", worktreeId: "wt", time: { updated: now - 1000 } },
+    ] as any[];
+    const result = groupAndSortSessions(sessions);
+    expect(result.map((s: any) => s.id)).toEqual(["n2", "n1", "w2", "w1"]);
+  });
+
+  it("groups worktree sessions by worktreeId and sorts groups by most-recent session", () => {
+    const now = Date.now();
+    const sessions = [
+      { id: "a1", worktreeId: "alpha", time: { updated: now - 5000 } },
+      { id: "b1", worktreeId: "beta", time: { updated: now - 1000 } },
+      { id: "a2", worktreeId: "alpha", time: { updated: now - 3000 } },
+    ] as any[];
+    const result = groupAndSortSessions(sessions);
+    // beta group (most recent at now-1000) comes before alpha group (now-3000)
+    expect(result.map((s: any) => s.id)).toEqual(["b1", "a2", "a1"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(groupAndSortSessions([])).toEqual([]);
   });
 });

--- a/tests/unit/electron/channels/teams/teams-adapter.test.ts
+++ b/tests/unit/electron/channels/teams/teams-adapter.test.ts
@@ -680,15 +680,15 @@ describe("TeamsAdapter", () => {
       const a = makeAdapterWithStubs();
       a.gatewayClient = { listAllProjects: vi.fn(async () => []) };
       await a.showProjectList("c1");
-      expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
+      expect(a.sessionMapper.getPendingSelection("c1")).toEqual({ type: "project", projects: [] });
     });
 
     it("showSessionListForProject filters by directory", async () => {
       const a = makeAdapterWithStubs();
       a.gatewayClient = {
         listAllSessions: vi.fn(async () => [
-          { id: "s1", directory: "/a", engineType: "claude", title: "x" },
-          { id: "s2", directory: "/b", engineType: "claude", title: "y" },
+          { id: "s1", directory: "/a", engineType: "claude", title: "x", projectId: "p" },
+          { id: "s2", directory: "/b", engineType: "claude", title: "y", projectId: "other" },
         ]),
       };
       await a.showSessionListForProject(

--- a/tests/unit/electron/channels/telegram/telegram-adapter.test.ts
+++ b/tests/unit/electron/channels/telegram/telegram-adapter.test.ts
@@ -656,7 +656,7 @@ describe("TelegramAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = { listAllProjects: vi.fn(async () => []) };
       await a.showProjectList("c1");
-      expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
+      expect(a.sessionMapper.getPendingSelection("c1")).toEqual({ type: "project", projects: [] });
     });
 
     it("showProjectList no-ops without gatewayClient", async () => {
@@ -671,8 +671,8 @@ describe("TelegramAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = {
         listAllSessions: vi.fn(async () => [
-          { id: "s1", directory: "/a", engineType: "claude", title: "x" },
-          { id: "s2", directory: "/b", engineType: "claude", title: "y" },
+          { id: "s1", directory: "/a", engineType: "claude", title: "x", projectId: "p" },
+          { id: "s2", directory: "/b", engineType: "claude", title: "y", projectId: "other" },
         ]),
       };
       await a.showSessionListForProject(

--- a/tests/unit/electron/channels/wecom/wecom-adapter.test.ts
+++ b/tests/unit/electron/channels/wecom/wecom-adapter.test.ts
@@ -554,7 +554,7 @@ describe("WeComAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = { listAllProjects: vi.fn(async () => []) };
       await a.showProjectList("c1");
-      expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
+      expect(a.sessionMapper.getPendingSelection("c1")).toEqual({ type: "project", projects: [] });
     });
 
     it("showSessionListForProject filters by directory and stores pending", async () => {
@@ -562,8 +562,8 @@ describe("WeComAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = {
         listAllSessions: vi.fn(async () => [
-          { id: "s1", directory: "/a", engineType: "claude", title: "x" },
-          { id: "s2", directory: "/b", engineType: "claude", title: "y" },
+          { id: "s1", directory: "/a", engineType: "claude", title: "x", projectId: "p" },
+          { id: "s2", directory: "/b", engineType: "claude", title: "y", projectId: "other" },
         ]),
       };
       await a.showSessionListForProject(
@@ -591,7 +591,7 @@ describe("WeComAdapter", () => {
         "alpha",
       );
       expect(a.sessionMapper.getTempSession("c1")?.conversationId).toBe("sess-1");
-      expect(a.transport.sendText.mock.calls.at(-1)[1]).toContain("已创建新会话");
+      expect(a.transport.sendText.mock.calls.at(-1)[1]).toContain("alpha");
     });
 
     it("reports error when createSession fails", async () => {

--- a/tests/unit/electron/channels/weixin-ilink/weixin-ilink-adapter.test.ts
+++ b/tests/unit/electron/channels/weixin-ilink/weixin-ilink-adapter.test.ts
@@ -434,7 +434,7 @@ describe("WeixinIlinkAdapter", () => {
       expect(temp.conversationId).toBe("sess-ABCDEFGH");
       expect(adapter.transport.sendText).toHaveBeenCalled();
       const arg = adapter.transport.sendText.mock.calls[0][1] as string;
-      expect(arg).toContain("Hi");
+      expect(arg).toContain("sess-ABC");
     });
   });
 
@@ -724,7 +724,7 @@ describe("WeixinIlinkAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = { listAllProjects: vi.fn(async () => []) };
       await a.showProjectList("c1");
-      expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
+      expect(a.sessionMapper.getPendingSelection("c1")).toEqual({ type: "project", projects: [] });
     });
 
     it("showSessionListForProject filters sessions by directory and stores pending", async () => {
@@ -732,8 +732,8 @@ describe("WeixinIlinkAdapter", () => {
       a.transport = { sendText: vi.fn(async () => "") };
       a.gatewayClient = {
         listAllSessions: vi.fn(async () => [
-          { id: "s1", directory: "/a", engineType: "claude", title: "x" },
-          { id: "s2", directory: "/b", engineType: "claude", title: "y" },
+          { id: "s1", directory: "/a", engineType: "claude", title: "x", projectId: "p" },
+          { id: "s2", directory: "/b", engineType: "claude", title: "y", projectId: "other" },
         ]),
       };
       await a.showSessionListForProject(
@@ -763,7 +763,7 @@ describe("WeixinIlinkAdapter", () => {
       );
       const t = a.sessionMapper.getTempSession("c1");
       expect(t?.conversationId).toBe("sess-1");
-      expect(a.transport.sendText.mock.calls.at(-1)[1]).toContain("已创建会话");
+      expect(a.transport.sendText.mock.calls.at(-1)[1]).toContain("proj");
     });
 
     it("createNewSessionForProject reports error message on failure", async () => {


### PR DESCRIPTION
## Summary

Closes #129.

- **Worktree sessions invisible**: Filter by `projectId` instead of `directory` so worktree sessions appear in session lists (all 7 adapter locations)
- **Hard limit of 9 sessions**: Remove `slice(0, 9)` — display all sessions with continuous numbering (two-digit numbers work fine)
- **Selection index mismatch**: Extract sorting to `groupAndSortSessions()` called by the caller, so `pendingSelection` array order matches display order
- **Worktree grouping**: Group worktree sessions under `🌿 {worktreeId}` headers with per-group recency sorting
- **Default workspace fallback**: Sync step 6 (default workspace auto-use) to all 6 adapters; do NOT set `lastSelectedProject` so temp session expiry correctly re-triggers step 6
- **P2P status notification**: Add `buildSessionNotification()` — shown on session create/switch (not on reuse) so users know which project and session they're in: `📋 codemux（claude）· abc12345`
- **Empty project list UX**: Show guidance text instead of a dead-end loop

### New shared helpers (`list-builders.ts`)

| Function | Purpose |
|---|---|
| `groupAndSortSessions()` | Normal sessions first (by recency), then worktree groups (each sorted, groups by most-recent) |
| `buildSessionNotification()` | One-line status: project name, engine type, short session ID |
| `relativeTimeZh()` | Chinese relative time labels for session list |
| `truncateTitle()` | Truncate session titles to 28 chars |

### Adapter changes (all 6 + Teams group-bind)

- `showSessionListForProject`: `s.projectId === project.projectId` filter + `groupAndSortSessions`
- `handleP2PMessage` step 6: default workspace fallback with cleanup, no `setP2PLastProject`
- `showProjectList`: no `setP2PLastProject` in default workspace branch
- `createTempSessionAndSend`: accepts optional `projectName`, sends `buildSessionNotification` after creation
- `createNewSessionForProject` / `handleSessionSelection`: unified notification format
- `handleProjectSelection`: re-fetch projects on empty list

## Test plan

- [x] `npm run typecheck` passes
- [x] 48 unit tests pass (`command-parser.test.ts`):
  - `relativeTimeZh` — all time intervals
  - `truncateTitle` — under/at/over limit
  - `groupAndSortSessions` — normal-first, worktree grouping, inter-group ordering
  - `buildSessionListText` — worktree headers, continuous numbering, title truncation
  - `buildSessionNotification` — project name, engine type, short session ID
- [ ] Manual: verify session list in a P2P channel shows worktree sessions grouped
- [ ] Manual: verify status notification on session create/switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)