### PR TITLE
Persist channel config in userData during dev

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,7 +365,7 @@ Feishu Bot (webhook)
           └─ WebSocket → GatewayServer (same protocol as UI)
 ```
 
-- `ChannelManager` manages channel lifecycle, config persistence (`.channels/` dir), and IPC handlers
+- `ChannelManager` manages channel lifecycle, config persistence (`userData/channels` dir), and IPC handlers
 - Each channel adapter extends `ChannelAdapter` base class
 - Channels connect to the gateway as internal WS clients, reusing the same protocol as the UI
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,7 +213,7 @@ Feishu Bot (webhook)
           └─ WebSocket → GatewayServer (same as UI)
 ```
 
-- `ChannelManager` manages channel lifecycle, config persistence (`.channels/` dir), and IPC handlers
+- `ChannelManager` manages channel lifecycle, config persistence (`userData/channels` dir), and IPC handlers
 - Each channel adapter extends `ChannelAdapter` base class
 - Channels connect to the gateway as internal WS clients, reusing the same protocol as the UI
 

--- a/docs/channels/dingtalk/README.md
+++ b/docs/channels/dingtalk/README.md
@@ -130,5 +130,5 @@ The ActionCard includes:
 - **Token Refresh**: Auto-refresh every 2 hours
 - **Message Format**: ActionCard (Markdown), plain text
 - **Group API**: Scene group creation via `POST /v1.0/im/interconnections/groups`
-- **Persistence**: Group bindings saved to `~/.channels/dingtalk-bindings.json`
+- **Persistence**: Group bindings saved to Electron `userData/channels/dingtalk-bindings.json`
 - **Rate Limiting**: TokenBucket — 5 burst capacity, ~0.33 tokens/sec (20/min)

--- a/docs/channels/feishu/README.md
+++ b/docs/channels/feishu/README.md
@@ -209,5 +209,5 @@ Update throttle is 1.5 seconds by default to stay within Feishu's API rate limit
 - **SDK**: `@larksuiteoapi/node-sdk` (official Lark Node.js SDK)
 - **Connection**: WebSocket (WSClient) — persistent connection from CodeMux to Feishu or Lark cloud
 - **Message Format**: Interactive Cards with Markdown content
-- **Persistence**: Group-session bindings saved to `~/.channels/feishu-bindings.json`
+- **Persistence**: Group-session bindings saved to Electron `userData/channels/feishu-bindings.json`
 - **Rate Limiting**: TokenBucket — 5 burst capacity, 5 tokens/sec refill

--- a/docs/channels/telegram/README.md
+++ b/docs/channels/telegram/README.md
@@ -138,5 +138,5 @@ Type `/help` in chat to see all available commands. Commands work in both P2P an
 - **Webhook Endpoint**: `/webhook/telegram` (POST)
 - **Webhook Auth**: Optional `X-Telegram-Bot-Api-Secret-Token` header verification
 - **Message Format**: MarkdownV2 with InlineKeyboardMarkup for interactive elements
-- **Persistence**: Session bindings saved to `~/.channels/telegram-bindings.json`
+- **Persistence**: Session bindings saved to Electron `userData/channels/telegram-bindings.json`
 - **Rate Limiting**: TokenBucket — 10 burst capacity, 30 tokens/sec refill

--- a/docs/channels/wecom/README.md
+++ b/docs/channels/wecom/README.md
@@ -164,5 +164,5 @@ WeCom **does not support editing sent messages**. Because of this:
 - **Authentication**: Token verification + AES message decryption
 - **Message Format**: Markdown text (no ActionCards in current implementation)
 - **Group API**: Not used — WeCom requires ≥2 members for group chats, so P2P mode is used instead
-- **Persistence**: Session state saved to `~/.channels/wecom-bindings.json`
+- **Persistence**: Session state saved to Electron `userData/channels/wecom-bindings.json`
 - **Rate Limiting**: TokenBucket — 5 burst capacity, 0.5 tokens/sec (30/min)

--- a/docs/channels/weixin-ilink/README.md
+++ b/docs/channels/weixin-ilink/README.md
@@ -126,7 +126,7 @@ You'll need to click **Login** and rescan the QR code to bring the bot back.
 - **Session expiry signal**: `errcode == -14` or `ret == -14`
 - **Capabilities**: `supportsMessageUpdate=false`, `supportsMessageDelete=false`, `supportsRichContent=false`, `maxMessageBytes=4096` → `StreamingController` runs in batch mode
 - **Persistence**:
-  - Channel config: `~/Library/Application Support/codemux/channels/weixin-ilink.json` (or `.channels/weixin-ilink.json` in dev)
-  - Session bindings: `~/Library/Application Support/codemux/channels/weixin-ilink-bindings.json`
+  - Channel config: Electron `userData/channels/weixin-ilink.json`
+  - Session bindings: Electron `userData/channels/weixin-ilink-bindings.json`
 - **Temp session TTL**: 2 hours of inactivity, then garbage-collected
 - **Reference**: protocol verified against [hello-halo](https://github.com/) `ilink-api.ts`

--- a/electron/main/channels/base-session-mapper.ts
+++ b/electron/main/channels/base-session-mapper.ts
@@ -143,9 +143,7 @@ export class BaseSessionMapper<
   // =========================================================================
 
   private getBindingsFilePath(): string {
-    const dir = app.isPackaged
-      ? path.join(app.getPath("userData"), "channels")
-      : path.join(process.cwd(), ".channels");
+    const dir = path.join(app.getPath("userData"), "channels");
     return path.join(dir, this.bindingsFileName);
   }
 

--- a/electron/main/channels/channel-manager.ts
+++ b/electron/main/channels/channel-manager.ts
@@ -17,9 +17,6 @@ import type { WebhookServer } from "./webhook-server";
 // --- Config persistence helpers ---
 
 function getChannelConfigDir(): string {
-  if (!app.isPackaged) {
-    return path.join(process.cwd(), ".channels");
-  }
   return path.join(app.getPath("userData"), "channels");
 }
 

--- a/electron/main/channels/feishu/feishu-session-mapper.ts
+++ b/electron/main/channels/feishu/feishu-session-mapper.ts
@@ -26,9 +26,7 @@ interface PersistedGroupBinding {
 }
 
 function getBindingsFilePath(): string {
-  const dir = app.isPackaged
-    ? path.join(app.getPath("userData"), "channels")
-    : path.join(process.cwd(), ".channels");
+  const dir = path.join(app.getPath("userData"), "channels");
   return path.join(dir, "feishu-bindings.json");
 }
 

--- a/tests/unit/electron/channels/adapter-update-config.test.ts
+++ b/tests/unit/electron/channels/adapter-update-config.test.ts
@@ -23,7 +23,7 @@ vi.mock("../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 

--- a/tests/unit/electron/channels/base-session-mapper.test.ts
+++ b/tests/unit/electron/channels/base-session-mapper.test.ts
@@ -239,12 +239,13 @@ describe("BaseSessionMapper", () => {
       (app as any).isPackaged = false;
     });
 
-    it("uses cwd path when app.isPackaged is false", () => {
-      const cwdSpy = vi.spyOn(process, "cwd").mockReturnValue("/mock/cwd");
+    it("uses userData path when app.isPackaged is false", async () => {
+      const { app } = await import("electron");
+      (app as any).isPackaged = false;
+
       mapper.createGroupBinding(makeBinding("chat-y", "conv-y"));
 
-      expect(cwdSpy).toHaveBeenCalled();
-      cwdSpy.mockRestore();
+      expect(app.getPath).toHaveBeenCalledWith("userData");
     });
   });
 

--- a/tests/unit/electron/channels/channel-manager.test.ts
+++ b/tests/unit/electron/channels/channel-manager.test.ts
@@ -61,8 +61,7 @@ describe("ChannelManager", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(tmpDirBase);
-    channelConfigDir = path.join(tmpDir, ".channels");
-    vi.spyOn(process, "cwd").mockReturnValue(tmpDir);
+    channelConfigDir = path.join(tmpDir, "channels");
     manager = new ChannelManager();
     mockAdapter = new MockChannelAdapter("test-channel");
   });

--- a/tests/unit/electron/channels/dingtalk/dingtalk-adapter.test.ts
+++ b/tests/unit/electron/channels/dingtalk/dingtalk-adapter.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 

--- a/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
@@ -26,7 +26,7 @@ vi.mock("../../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 

--- a/tests/unit/electron/channels/teams/teams-adapter.test.ts
+++ b/tests/unit/electron/channels/teams/teams-adapter.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 

--- a/tests/unit/electron/channels/telegram/telegram-adapter.test.ts
+++ b/tests/unit/electron/channels/telegram/telegram-adapter.test.ts
@@ -21,7 +21,7 @@ vi.mock("../../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 

--- a/tests/unit/electron/channels/wecom/wecom-adapter.test.ts
+++ b/tests/unit/electron/channels/wecom/wecom-adapter.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 

--- a/tests/unit/electron/channels/weixin-ilink/weixin-ilink-adapter.test.ts
+++ b/tests/unit/electron/channels/weixin-ilink/weixin-ilink-adapter.test.ts
@@ -20,7 +20,7 @@ vi.mock("../../../../../electron/main/services/logger", () => ({
 vi.mock("electron", () => ({
   app: {
     isPackaged: false,
-    getPath: vi.fn(() => "/mock/userData"),
+    getPath: vi.fn(() => process.env.RUNNER_TEMP ?? process.env.TMPDIR ?? process.cwd()),
   },
 }));
 


### PR DESCRIPTION
## Summary
- Store channel configs and session bindings under Electron `userData/channels` in both development and production.
- Update channel persistence tests to assert development mode uses `userData` instead of the repo-local `.channels` directory.
- Refresh channel docs to describe the unified `userData/channels` location.

## Test plan
- [x] `bun run test:unit -- tests/unit/electron/channels/channel-manager.test.ts tests/unit/electron/channels/base-session-mapper.test.ts tests/unit/electron/channels/feishu/feishu-session-mapper.test.ts`
- [x] `git diff --check`
- [ ] `bun run typecheck` currently fails on `electron/main/engines/opencode/converters.ts` with existing OpenCode SDK type errors unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)