### PR TITLE
Fix Cloudflare named tunnel custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,33 @@ After a browser has been approved, it can open **Settings → Channels** in the 
 | Method | Setup | Best For |
 |--------|-------|----------|
 | **LAN Browser** | Open `http://<your-ip>:8233`, enter 6-digit code or scan QR | Quick access from another device on the same network |
-| **Public Internet** | Toggle "Public Access" → share `*.trycloudflare.com` URL | Access from anywhere, no port forwarding needed |
+| **Public Internet** | Toggle "Public Access" → share `*.trycloudflare.com` URL, or configure a custom domain with named tunnel credentials | Access from anywhere, no port forwarding needed |
 | **IM Bot** | Configure bot credentials in Settings → Channels (desktop or approved web UI) | Interact from Feishu, DingTalk, Telegram, WeCom, or Teams |
+
+### Cloudflare Custom Domains
+
+CodeMux uses Cloudflare quick tunnels by default. Quick tunnels require no Cloudflare account setup and produce a temporary `*.trycloudflare.com` URL each time they start.
+
+A custom domain requires a Cloudflare named tunnel and a local tunnel credential file. CodeMux looks for a UUID-named JSON file in `~/.cloudflared/`, for example `~/.cloudflared/<tunnel-id>.json`. If a custom domain is configured but that credential is missing, CodeMux will stop startup with a missing-credentials error instead of silently falling back to a random quick tunnel URL.
+
+To prepare a custom domain:
+
+```bash
+# Sign in and choose the Cloudflare zone for your domain.
+# This writes ~/.cloudflared/cert.pem.
+cloudflared tunnel login
+
+# If the tunnel already exists, find its name and UUID.
+cloudflared tunnel list
+
+# Download/write the connector credential that CodeMux can detect.
+cloudflared tunnel token --cred-file ~/.cloudflared/<tunnel-id>.json <tunnel-name-or-id>
+
+# Route the hostname to that named tunnel, if it is not already routed.
+cloudflared tunnel route dns <tunnel-name-or-id> <your-domain>
+```
+
+If you do not already have a named tunnel, create one first with `cloudflared tunnel create <tunnel-name>`; that command also writes the credential JSON. Keep `cert.pem` and `<tunnel-id>.json` private and never commit them to the repository.
 
 ### Security & Device Management
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,8 +204,33 @@ bun run dev
 | 方式 | 配置 | 适用场景 |
 |------|------|---------|
 | **局域网浏览器** | 打开 `http://<你的IP>:8233`，输入 6 位访问码或扫描二维码 | 同一网络下从另一台设备快速访问 |
-| **公网** | 开启"公网访问" → 分享 `*.trycloudflare.com` URL | 从任何地方访问，无需端口转发 |
+| **公网** | 开启"公网访问" → 分享 `*.trycloudflare.com` URL，或在准备好命名隧道凭证后配置自定义域名 | 从任何地方访问，无需端口转发 |
 | **IM 机器人** | 在设置 → 渠道中配置机器人凭证 | 通过飞书、钉钉、Telegram、企业微信或 Teams 交互 |
+
+### Cloudflare 自定义域名
+
+CodeMux 默认使用 Cloudflare quick tunnel。quick tunnel 不需要 Cloudflare 账号配置，每次启动都会生成一个临时的 `*.trycloudflare.com` URL。
+
+自定义域名需要 Cloudflare named tunnel 以及本机的 tunnel credential 文件。CodeMux 会在 `~/.cloudflared/` 下查找以 UUID 命名的 JSON 文件，例如 `~/.cloudflared/<tunnel-id>.json`。如果配置了自定义域名但缺少这个 credential，CodeMux 会直接停止启动并显示缺少凭证错误，而不会静默回退到随机 quick tunnel URL。
+
+准备自定义域名的步骤：
+
+```bash
+# 登录 Cloudflare，并选择你的域名所在 zone。
+# 这会写入 ~/.cloudflared/cert.pem。
+cloudflared tunnel login
+
+# 如果 tunnel 已经存在，先找到它的名称和 UUID。
+cloudflared tunnel list
+
+# 下载/写入 CodeMux 可检测到的 connector credential。
+cloudflared tunnel token --cred-file ~/.cloudflared/<tunnel-id>.json <tunnel-name-or-id>
+
+# 如果域名还没有指向该 named tunnel，则创建 DNS route。
+cloudflared tunnel route dns <tunnel-name-or-id> <your-domain>
+```
+
+如果还没有 named tunnel，先运行 `cloudflared tunnel create <tunnel-name>` 创建；这个命令也会写入 credential JSON。`cert.pem` 和 `<tunnel-id>.json` 都是私密凭证，不要提交到仓库。
 
 ### 安全与设备管理
 

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -150,17 +150,14 @@ export function registerIpcHandlers(): void {
   // Tunnel Management
   // ===========================================================================
 
-  ipcMain.handle("tunnel:start", async (_, port: number) => {
+  ipcMain.handle("tunnel:start", async (_, port: number, tunnelConfig?: { hostname?: string }) => {
     // In production, use the production server port if available
     const actualPort = app.isPackaged && productionServer.isRunning()
       ? productionServer.getPort()
       : port;
 
-    // Read tunnel config from settings
-    const settings = loadSettings();
-    const tunnelConfig = settings.tunnelConfig as { hostname?: string } | undefined;
-
-    return tunnelManager.start(actualPort, tunnelConfig);
+    const config = tunnelConfig ?? (loadSettings().tunnelConfig as { hostname?: string } | undefined);
+    return tunnelManager.start(actualPort, config);
   });
 
   ipcMain.handle("tunnel:stop", async () => {

--- a/electron/main/services/tunnel-manager.ts
+++ b/electron/main/services/tunnel-manager.ts
@@ -16,6 +16,8 @@ interface TunnelInfo {
   startTime?: number;
   error?: string;
   errorCode?: string;
+  warning?: string;
+  warningCode?: string;
 }
 
 class TunnelManager {
@@ -99,27 +101,25 @@ class TunnelManager {
 
     const hostname = config?.hostname?.trim();
     let tunnelId: string | null = null;
+    let warning: string | undefined;
+    let warningCode: string | undefined;
     if (hostname) {
       tunnelId = this.detectTunnelId();
       if (!tunnelId) {
-        const error = "Named Tunnel credentials not found. Run cloudflared tunnel login, create a tunnel, and route DNS for this domain first.";
-        tunnelLog.error(error);
-        this.info = {
-          url: "",
-          status: "error",
-          error,
-          errorCode: "NAMED_TUNNEL_NO_CREDENTIALS",
-        };
-        return this.info;
+        warning = "Named Tunnel credentials not found. Starting a temporary quick tunnel instead.";
+        warningCode = "NAMED_TUNNEL_NO_CREDENTIALS";
+        tunnelLog.warn(warning);
       }
     }
-    const isNamed = !!hostname;
+    const isNamed = !!(hostname && tunnelId);
 
     this.stoppedByUser = false;
     this.info = {
       url: "",
       status: "starting",
       startTime: Date.now(),
+      warning,
+      warningCode,
     };
 
     try {
@@ -166,6 +166,8 @@ class TunnelManager {
               url: urlMatch[0],
               status: "running",
               startTime: this.info.startTime,
+              warning: this.info.warning,
+              warningCode: this.info.warningCode,
             };
             tunnelLog.info("URL Ready:", this.info.url);
           }

--- a/electron/main/services/tunnel-manager.ts
+++ b/electron/main/services/tunnel-manager.ts
@@ -16,8 +16,6 @@ interface TunnelInfo {
   startTime?: number;
   error?: string;
   errorCode?: string;
-  warning?: string;
-  warningCode?: string;
 }
 
 class TunnelManager {
@@ -101,25 +99,27 @@ class TunnelManager {
 
     const hostname = config?.hostname?.trim();
     let tunnelId: string | null = null;
-    let warning: string | undefined;
-    let warningCode: string | undefined;
     if (hostname) {
       tunnelId = this.detectTunnelId();
       if (!tunnelId) {
-        warning = "Named Tunnel credentials not found. Starting a temporary quick tunnel instead.";
-        warningCode = "NAMED_TUNNEL_NO_CREDENTIALS";
-        tunnelLog.warn(warning);
+        const error = "Named Tunnel credentials not found. CodeMux needs a ~/.cloudflared/<tunnel-id>.json credential file to start this fixed custom domain. Run cloudflared tunnel login, cloudflared tunnel create <name>, and cloudflared tunnel route dns <name> <domain>; or clear the custom domain to use a temporary quick tunnel.";
+        tunnelLog.error(error);
+        this.info = {
+          url: "",
+          status: "error",
+          error,
+          errorCode: "NAMED_TUNNEL_NO_CREDENTIALS",
+        };
+        return this.info;
       }
     }
-    const isNamed = !!(hostname && tunnelId);
+    const isNamed = !!hostname;
 
     this.stoppedByUser = false;
     this.info = {
       url: "",
       status: "starting",
       startTime: Date.now(),
-      warning,
-      warningCode,
     };
 
     try {
@@ -166,8 +166,6 @@ class TunnelManager {
               url: urlMatch[0],
               status: "running",
               startTime: this.info.startTime,
-              warning: this.info.warning,
-              warningCode: this.info.warningCode,
             };
             tunnelLog.info("URL Ready:", this.info.url);
           }

--- a/electron/main/services/tunnel-manager.ts
+++ b/electron/main/services/tunnel-manager.ts
@@ -15,6 +15,7 @@ interface TunnelInfo {
   status: "starting" | "running" | "stopped" | "error";
   startTime?: number;
   error?: string;
+  errorCode?: string;
 }
 
 class TunnelManager {
@@ -101,10 +102,18 @@ class TunnelManager {
     if (hostname) {
       tunnelId = this.detectTunnelId();
       if (!tunnelId) {
-        tunnelLog.warn("Named tunnel hostname configured but no tunnel credentials found in ~/.cloudflared/");
+        const error = "Named Tunnel credentials not found. Run cloudflared tunnel login, create a tunnel, and route DNS for this domain first.";
+        tunnelLog.error(error);
+        this.info = {
+          url: "",
+          status: "error",
+          error,
+          errorCode: "NAMED_TUNNEL_NO_CREDENTIALS",
+        };
+        return this.info;
       }
     }
-    const isNamed = !!(hostname && tunnelId);
+    const isNamed = !!hostname;
 
     this.stoppedByUser = false;
     this.info = {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -39,7 +39,7 @@ const electronAPI = {
 
   // Tunnel API
   tunnel: {
-    start: (port: number) => ipcRenderer.invoke("tunnel:start", port),
+    start: (port: number, tunnelConfig?: { hostname?: string }) => ipcRenderer.invoke("tunnel:start", port, tunnelConfig),
     stop: () => ipcRenderer.invoke("tunnel:stop"),
     getStatus: () => ipcRenderer.invoke("tunnel:getStatus"),
     onDisconnected: (callback: () => void) => {

--- a/src/lib/electron-api.ts
+++ b/src/lib/electron-api.ts
@@ -21,6 +21,7 @@ export interface TunnelInfo {
   status: "starting" | "running" | "stopped" | "error";
   startTime?: number;
   error?: string;
+  errorCode?: string;
 }
 
 export interface TunnelConfig {
@@ -243,9 +244,9 @@ export const devicesAPI = {
 
 // Tunnel API
 export const tunnelAPI = {
-  async start(port: number = WEB_STANDALONE_PORT): Promise<TunnelInfo | null> {
+  async start(port: number = WEB_STANDALONE_PORT, tunnelConfig?: TunnelConfig): Promise<TunnelInfo | null> {
     const api = getElectronAPI();
-    return api ? api.tunnel.start(port) : null;
+    return api ? api.tunnel.start(port, tunnelConfig) : null;
   },
 
   async stop(): Promise<void> {

--- a/src/lib/electron-api.ts
+++ b/src/lib/electron-api.ts
@@ -22,8 +22,6 @@ export interface TunnelInfo {
   startTime?: number;
   error?: string;
   errorCode?: string;
-  warning?: string;
-  warningCode?: string;
 }
 
 export interface TunnelConfig {

--- a/src/lib/electron-api.ts
+++ b/src/lib/electron-api.ts
@@ -22,6 +22,8 @@ export interface TunnelInfo {
   startTime?: number;
   error?: string;
   errorCode?: string;
+  warning?: string;
+  warningCode?: string;
 }
 
 export interface TunnelConfig {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -45,11 +45,11 @@ function getRendererCache(): Record<string, unknown> | null {
   return null;
 }
 
-function electronSave(patch: Record<string, unknown>): void {
+function electronSave(patch: Record<string, unknown>): Promise<void> {
   try {
-    (window as any).electronAPI?.settings?.save(patch);
+    return Promise.resolve((window as any).electronAPI?.settings?.save(patch)).then(() => {}, () => {});
   } catch {
-    // ignore — not in Electron
+    return Promise.resolve();
   }
 }
 
@@ -76,15 +76,16 @@ export function getSetting<T = unknown>(key: string): T | undefined {
 }
 
 /** Save a setting value. Async write to settings.json in Electron, localStorage in web. */
-export function saveSetting(key: string, value: unknown): void {
-  if (isElectron()) {
+export async function saveSetting(key: string, value: unknown): Promise<void> {
+  const savePromise = isElectron() ? (() => {
     // Update renderer-side cache immediately so subsequent reads see the new value
     const cache = getRendererCache();
     if (cache) {
       cache[key] = value;
     }
-    electronSave({ [key]: value });
-  }
+    return electronSave({ [key]: value });
+  })() : null;
+
   // Always write to localStorage as well for web mode and as immediate cache
   try {
     localStorage.setItem(`settings:${key}`, JSON.stringify(value));
@@ -108,6 +109,10 @@ export function saveSetting(key: string, value: unknown): void {
       // Best-effort — swallow errors
     }
   }
+
+  if (savePromise) {
+    await savePromise;
+  }
 }
 
 /** Read a nested setting (e.g. "engineModels.claude") */
@@ -127,11 +132,10 @@ export function getNestedSetting<T = unknown>(path: string): T | undefined {
 }
 
 /** Save a nested setting (e.g. "engineModels.claude", value) */
-export function saveNestedSetting(path: string, value: unknown): void {
+export function saveNestedSetting(path: string, value: unknown): Promise<void> {
   const parts = path.split(".");
   if (parts.length === 1) {
-    saveSetting(parts[0], value);
-    return;
+    return saveSetting(parts[0], value);
   }
 
   // Read root, merge nested, save entire root
@@ -144,7 +148,7 @@ export function saveNestedSetting(path: string, value: unknown): void {
     target = target[parts[i]] as Record<string, unknown>;
   }
   target[parts[parts.length - 1]] = value;
-  saveSetting(parts[0], root);
+  return saveSetting(parts[0], root);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -144,6 +144,7 @@ export interface LocaleDict {
     publicAccessDesc: string;
     starting: string;
     startFailed: string;
+    namedTunnelMissingCredentials: string;
     securityWarning: string;
     securityWarningDesc: string;
     accessPassword: string;
@@ -792,6 +793,7 @@ export const en: LocaleDict = {
     publicAccessDesc: "Access via Cloudflare tunnel from the internet",
     starting: "Starting tunnel, please wait...",
     startFailed: "Failed to start. Please ensure cloudflared is installed",
+    namedTunnelMissingCredentials: "Named Tunnel credentials were not found. Run the Cloudflare setup commands below before starting this custom domain.",
     securityWarning: "Security Warning:",
     securityWarningDesc: "Remote access allows full control of this device. Keep your access password safe and never share it with untrusted people.",
     accessPassword: "Access Password",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -793,7 +793,7 @@ export const en: LocaleDict = {
     publicAccessDesc: "Access via Cloudflare tunnel from the internet",
     starting: "Starting tunnel, please wait...",
     startFailed: "Failed to start. Please ensure cloudflared is installed",
-    namedTunnelMissingCredentials: "Named Tunnel credentials were not found. Run the Cloudflare setup commands below before starting this custom domain.",
+    namedTunnelMissingCredentials: "Named Tunnel credentials were not found, so CodeMux started a temporary quick tunnel. Run the Cloudflare setup commands below to use this fixed domain.",
     securityWarning: "Security Warning:",
     securityWarningDesc: "Remote access allows full control of this device. Keep your access password safe and never share it with untrusted people.",
     accessPassword: "Access Password",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -793,7 +793,7 @@ export const en: LocaleDict = {
     publicAccessDesc: "Access via Cloudflare tunnel from the internet",
     starting: "Starting tunnel, please wait...",
     startFailed: "Failed to start. Please ensure cloudflared is installed",
-    namedTunnelMissingCredentials: "Named Tunnel credentials were not found, so CodeMux started a temporary quick tunnel. Run the Cloudflare setup commands below to use this fixed domain.",
+    namedTunnelMissingCredentials: "Named Tunnel credentials were not found. CodeMux needs a ~/.cloudflared/<tunnel-id>.json credential file to start this fixed domain. Run the Cloudflare setup commands below, or clear the custom domain to use a temporary quick tunnel.",
     securityWarning: "Security Warning:",
     securityWarningDesc: "Remote access allows full control of this device. Keep your access password safe and never share it with untrusted people.",
     accessPassword: "Access Password",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -146,7 +146,7 @@ export const ru: LocaleDict = {
     publicAccessDesc: "Доступ через туннель Cloudflare из интернета",
     starting: "Запуск туннеля, подождите...",
     startFailed: "Не удалось запустить. Убедитесь, что cloudflared установлен",
-    namedTunnelMissingCredentials: "Учётные данные именованного Tunnel не найдены. Сначала выполните команды настройки Cloudflare ниже, затем запустите этот домен.",
+    namedTunnelMissingCredentials: "Учётные данные именованного Tunnel не найдены, поэтому CodeMux запустил временный quick tunnel. Выполните команды настройки Cloudflare ниже, чтобы использовать этот фиксированный домен.",
     securityWarning: "Предупреждение безопасности:",
     securityWarningDesc: "Удалённый доступ предоставляет полный контроль над этим устройством. Храните пароль в тайне и никому не передавайте.",
     accessPassword: "Пароль доступа",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -146,7 +146,7 @@ export const ru: LocaleDict = {
     publicAccessDesc: "Доступ через туннель Cloudflare из интернета",
     starting: "Запуск туннеля, подождите...",
     startFailed: "Не удалось запустить. Убедитесь, что cloudflared установлен",
-    namedTunnelMissingCredentials: "Учётные данные именованного Tunnel не найдены, поэтому CodeMux запустил временный quick tunnel. Выполните команды настройки Cloudflare ниже, чтобы использовать этот фиксированный домен.",
+    namedTunnelMissingCredentials: "Учётные данные именованного Tunnel не найдены. CodeMux нужен файл ~/.cloudflared/<tunnel-id>.json, чтобы запустить этот фиксированный домен. Выполните команды настройки Cloudflare ниже или очистите домен, чтобы использовать временный quick tunnel.",
     securityWarning: "Предупреждение безопасности:",
     securityWarningDesc: "Удалённый доступ предоставляет полный контроль над этим устройством. Храните пароль в тайне и никому не передавайте.",
     accessPassword: "Пароль доступа",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -146,6 +146,7 @@ export const ru: LocaleDict = {
     publicAccessDesc: "Доступ через туннель Cloudflare из интернета",
     starting: "Запуск туннеля, подождите...",
     startFailed: "Не удалось запустить. Убедитесь, что cloudflared установлен",
+    namedTunnelMissingCredentials: "Учётные данные именованного Tunnel не найдены. Сначала выполните команды настройки Cloudflare ниже, затем запустите этот домен.",
     securityWarning: "Предупреждение безопасности:",
     securityWarningDesc: "Удалённый доступ предоставляет полный контроль над этим устройством. Храните пароль в тайне и никому не передавайте.",
     accessPassword: "Пароль доступа",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -145,6 +145,7 @@ export const zh: LocaleDict = {
     publicAccessDesc: "通过 Cloudflare 隧道从互联网访问",
     starting: "正在启动隧道，请稍候...",
     startFailed: "启动失败，请确保已安装 cloudflared",
+    namedTunnelMissingCredentials: "未找到命名 Tunnel 凭证。请先完成下方 Cloudflare 设置命令，再启动这个自定义域名。",
     securityWarning: "安全提示：",
     securityWarningDesc: "远程访问允许完全控制此设备。请妥善保管访问密码，切勿分享给不信任的人。",
     accessPassword: "访问密码",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -145,7 +145,7 @@ export const zh: LocaleDict = {
     publicAccessDesc: "通过 Cloudflare 隧道从互联网访问",
     starting: "正在启动隧道，请稍候...",
     startFailed: "启动失败，请确保已安装 cloudflared",
-    namedTunnelMissingCredentials: "未找到命名 Tunnel 凭证。请先完成下方 Cloudflare 设置命令，再启动这个自定义域名。",
+    namedTunnelMissingCredentials: "未找到命名 Tunnel 凭证，CodeMux 已改用临时 quick tunnel。要使用这个固定域名，请完成下方 Cloudflare 设置命令。",
     securityWarning: "安全提示：",
     securityWarningDesc: "远程访问允许完全控制此设备。请妥善保管访问密码，切勿分享给不信任的人。",
     accessPassword: "访问密码",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -145,7 +145,7 @@ export const zh: LocaleDict = {
     publicAccessDesc: "通过 Cloudflare 隧道从互联网访问",
     starting: "正在启动隧道，请稍候...",
     startFailed: "启动失败，请确保已安装 cloudflared",
-    namedTunnelMissingCredentials: "未找到命名 Tunnel 凭证，CodeMux 已改用临时 quick tunnel。要使用这个固定域名，请完成下方 Cloudflare 设置命令。",
+    namedTunnelMissingCredentials: "未找到命名 Tunnel 凭证。CodeMux 需要 ~/.cloudflared/<tunnel-id>.json 凭证文件才能启动这个固定域名。请完成下方 Cloudflare 设置命令，或清空自定义域名以使用临时 quick tunnel。",
     securityWarning: "安全提示：",
     securityWarningDesc: "远程访问允许完全控制此设备。请妥善保管访问密码，切勿分享给不信任的人。",
     accessPassword: "访问密码",

--- a/src/pages/EntryPage.tsx
+++ b/src/pages/EntryPage.tsx
@@ -57,9 +57,9 @@ export default function EntryPage() {
   const [namedTunnelHostname, setNamedTunnelHostname] = createSignal(savedTunnelConfig.hostname || "");
 
   const isNamedTunnel = () => !!namedTunnelHostname().trim();
-  const tunnelWarningMessage = () => tunnelInfo().warningCode === "NAMED_TUNNEL_NO_CREDENTIALS"
+  const tunnelErrorMessage = () => tunnelInfo().errorCode === "NAMED_TUNNEL_NO_CREDENTIALS"
     ? t().remote.namedTunnelMissingCredentials
-    : tunnelInfo().warning;
+    : tunnelInfo().error;
   const [localIp, setLocalIp] = createSignal("127.0.0.1");
   const [accessCode, setAccessCode] = createSignal("......");
   const [port, setPort] = createSignal(WEB_STANDALONE_PORT);
@@ -2005,20 +2005,11 @@ export default function EntryPage() {
                           </div>
                         </Show>
 
-                        <Show when={tunnelInfo().error}>
+                        <Show when={tunnelErrorMessage()}>
                           <div class="px-4 py-3 bg-red-50 dark:bg-red-900/10 border-t border-red-100 dark:border-red-900/30">
                             <p class="text-xs text-red-600 dark:text-red-400 flex items-center gap-2">
                               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>
-                              {tunnelInfo().error}
-                            </p>
-                          </div>
-                        </Show>
-
-                        <Show when={tunnelWarningMessage()}>
-                          <div class="px-4 py-3 bg-amber-50 dark:bg-amber-900/10 border-t border-amber-100 dark:border-amber-900/30">
-                            <p class="text-xs text-amber-700 dark:text-amber-400 flex items-center gap-2">
-                              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>
-                              {tunnelWarningMessage()}
+                              {tunnelErrorMessage()}
                             </p>
                           </div>
                         </Show>
@@ -2056,7 +2047,7 @@ export default function EntryPage() {
                             />
                           </div>
 
-                          <Show when={!isNamedTunnel() || tunnelInfo().warningCode === "NAMED_TUNNEL_NO_CREDENTIALS"}>
+                          <Show when={!isNamedTunnel() || tunnelInfo().errorCode === "NAMED_TUNNEL_NO_CREDENTIALS"}>
                             <p class="mt-2 text-[11px] text-gray-400 dark:text-gray-500">{t().remote.namedTunnelSetupHint}</p>
                           </Show>
                           <Show when={isNamedTunnel()}>

--- a/src/pages/EntryPage.tsx
+++ b/src/pages/EntryPage.tsx
@@ -57,6 +57,9 @@ export default function EntryPage() {
   const [namedTunnelHostname, setNamedTunnelHostname] = createSignal(savedTunnelConfig.hostname || "");
 
   const isNamedTunnel = () => !!namedTunnelHostname().trim();
+  const tunnelErrorMessage = () => tunnelInfo().errorCode === "NAMED_TUNNEL_NO_CREDENTIALS"
+    ? t().remote.namedTunnelMissingCredentials
+    : tunnelInfo().error;
   const [localIp, setLocalIp] = createSignal("127.0.0.1");
   const [accessCode, setAccessCode] = createSignal("......");
   const [port, setPort] = createSignal(WEB_STANDALONE_PORT);
@@ -376,13 +379,15 @@ export default function EntryPage() {
 
   const startTunnel = async () => {
     setTunnelLoading(true);
-    saveNamedTunnelConfig();
     try {
+      await saveNamedTunnelConfig();
       let info: TunnelInfo;
+      const hostname = namedTunnelHostname().trim();
+      const tunnelConfig = hostname ? { hostname } : undefined;
 
       if (isElectron()) {
         // Electron: use IPC API
-        const result = await tunnelAPI.start(port());
+        const result = await tunnelAPI.start(port(), tunnelConfig);
         info = result || { url: "", status: "error", error: t().remote.startFailed };
       } else {
         // Browser: use HTTP API
@@ -391,7 +396,7 @@ export default function EntryPage() {
       }
 
       setTunnelInfo(info);
-      setTunnelEnabled(true);
+      setTunnelEnabled(info.status === "starting" || info.status === "running");
 
       if (info.status === "starting") {
         const pollInterval = setInterval(async () => {
@@ -446,13 +451,13 @@ export default function EntryPage() {
     }
   };
 
-  const saveNamedTunnelConfig = () => {
+  const saveNamedTunnelConfig = async () => {
     const hostname = namedTunnelHostname().trim();
     if (hostname) {
-      saveSetting("tunnelConfig", { hostname });
+      await saveSetting("tunnelConfig", { hostname });
     } else {
       // Clear the config entirely when hostname is removed
-      saveSetting("tunnelConfig", undefined);
+      await saveSetting("tunnelConfig", undefined);
     }
   };
 
@@ -2000,11 +2005,11 @@ export default function EntryPage() {
                           </div>
                         </Show>
 
-                        <Show when={tunnelInfo().error}>
+                        <Show when={tunnelErrorMessage()}>
                           <div class="px-4 py-3 bg-red-50 dark:bg-red-900/10 border-t border-red-100 dark:border-red-900/30">
                             <p class="text-xs text-red-600 dark:text-red-400 flex items-center gap-2">
                               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>
-                              {tunnelInfo().error}
+                              {tunnelErrorMessage()}
                             </p>
                           </div>
                         </Show>
@@ -2036,13 +2041,13 @@ export default function EntryPage() {
                               type="text"
                               value={namedTunnelHostname()}
                               onInput={(e) => setNamedTunnelHostname(e.currentTarget.value)}
-                              onBlur={saveNamedTunnelConfig}
+                              onBlur={() => { void saveNamedTunnelConfig(); }}
                               placeholder={t().remote.tunnelHostnamePlaceholder}
                               class="w-full px-3 py-1.5 text-sm rounded-md border border-gray-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                             />
                           </div>
 
-                          <Show when={!isNamedTunnel()}>
+                          <Show when={!isNamedTunnel() || tunnelInfo().errorCode === "NAMED_TUNNEL_NO_CREDENTIALS"}>
                             <p class="mt-2 text-[11px] text-gray-400 dark:text-gray-500">{t().remote.namedTunnelSetupHint}</p>
                           </Show>
                           <Show when={isNamedTunnel()}>

--- a/src/pages/EntryPage.tsx
+++ b/src/pages/EntryPage.tsx
@@ -57,9 +57,9 @@ export default function EntryPage() {
   const [namedTunnelHostname, setNamedTunnelHostname] = createSignal(savedTunnelConfig.hostname || "");
 
   const isNamedTunnel = () => !!namedTunnelHostname().trim();
-  const tunnelErrorMessage = () => tunnelInfo().errorCode === "NAMED_TUNNEL_NO_CREDENTIALS"
+  const tunnelWarningMessage = () => tunnelInfo().warningCode === "NAMED_TUNNEL_NO_CREDENTIALS"
     ? t().remote.namedTunnelMissingCredentials
-    : tunnelInfo().error;
+    : tunnelInfo().warning;
   const [localIp, setLocalIp] = createSignal("127.0.0.1");
   const [accessCode, setAccessCode] = createSignal("......");
   const [port, setPort] = createSignal(WEB_STANDALONE_PORT);
@@ -2005,11 +2005,20 @@ export default function EntryPage() {
                           </div>
                         </Show>
 
-                        <Show when={tunnelErrorMessage()}>
+                        <Show when={tunnelInfo().error}>
                           <div class="px-4 py-3 bg-red-50 dark:bg-red-900/10 border-t border-red-100 dark:border-red-900/30">
                             <p class="text-xs text-red-600 dark:text-red-400 flex items-center gap-2">
                               <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>
-                              {tunnelErrorMessage()}
+                              {tunnelInfo().error}
+                            </p>
+                          </div>
+                        </Show>
+
+                        <Show when={tunnelWarningMessage()}>
+                          <div class="px-4 py-3 bg-amber-50 dark:bg-amber-900/10 border-t border-amber-100 dark:border-amber-900/30">
+                            <p class="text-xs text-amber-700 dark:text-amber-400 flex items-center gap-2">
+                              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" x2="12" y1="8" y2="12"/><line x1="12" x2="12.01" y1="16" y2="16"/></svg>
+                              {tunnelWarningMessage()}
                             </p>
                           </div>
                         </Show>
@@ -2047,7 +2056,7 @@ export default function EntryPage() {
                             />
                           </div>
 
-                          <Show when={!isNamedTunnel() || tunnelInfo().errorCode === "NAMED_TUNNEL_NO_CREDENTIALS"}>
+                          <Show when={!isNamedTunnel() || tunnelInfo().warningCode === "NAMED_TUNNEL_NO_CREDENTIALS"}>
                             <p class="mt-2 text-[11px] text-gray-400 dark:text-gray-500">{t().remote.namedTunnelSetupHint}</p>
                           </Show>
                           <Show when={isNamedTunnel()}>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -62,11 +62,12 @@ interface ElectronAPI {
   };
 
   tunnel: {
-    start: (port: number) => Promise<{
+    start: (port: number, tunnelConfig?: { hostname?: string }) => Promise<{
       url: string;
       status: "starting" | "running" | "stopped" | "error";
       startTime?: number;
       error?: string;
+      errorCode?: string;
     }>;
     stop: () => Promise<void>;
     getStatus: () => Promise<{
@@ -74,6 +75,7 @@ interface ElectronAPI {
       status: "starting" | "running" | "stopped" | "error";
       startTime?: number;
       error?: string;
+      errorCode?: string;
     }>;
     onDisconnected: (callback: () => void) => () => void;
   };

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -68,8 +68,6 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
-      warning?: string;
-      warningCode?: string;
     }>;
     stop: () => Promise<void>;
     getStatus: () => Promise<{
@@ -78,8 +76,6 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
-      warning?: string;
-      warningCode?: string;
     }>;
     onDisconnected: (callback: () => void) => () => void;
   };

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -68,6 +68,8 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
+      warning?: string;
+      warningCode?: string;
     }>;
     stop: () => Promise<void>;
     getStatus: () => Promise<{
@@ -76,6 +78,8 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
+      warning?: string;
+      warningCode?: string;
     }>;
     onDisconnected: (callback: () => void) => () => void;
   };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -52,11 +52,12 @@ interface ElectronAPI {
   };
 
   tunnel: {
-    start: (port: number) => Promise<{
+    start: (port: number, tunnelConfig?: { hostname?: string }) => Promise<{
       url: string;
       status: "starting" | "running" | "stopped" | "error";
       startTime?: number;
       error?: string;
+      errorCode?: string;
     } | null>;
     stop: () => Promise<void>;
     getStatus: () => Promise<{
@@ -64,6 +65,7 @@ interface ElectronAPI {
       status: "starting" | "running" | "stopped" | "error";
       startTime?: number;
       error?: string;
+      errorCode?: string;
     } | null>;
     onDisconnected: (callback: () => void) => () => void;
   };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -58,8 +58,6 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
-      warning?: string;
-      warningCode?: string;
     } | null>;
     stop: () => Promise<void>;
     getStatus: () => Promise<{
@@ -68,8 +66,6 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
-      warning?: string;
-      warningCode?: string;
     } | null>;
     onDisconnected: (callback: () => void) => () => void;
   };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -58,6 +58,8 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
+      warning?: string;
+      warningCode?: string;
     } | null>;
     stop: () => Promise<void>;
     getStatus: () => Promise<{
@@ -66,6 +68,8 @@ interface ElectronAPI {
       startTime?: number;
       error?: string;
       errorCode?: string;
+      warning?: string;
+      warningCode?: string;
     } | null>;
     onDisconnected: (callback: () => void) => () => void;
   };

--- a/tests/unit/electron/ipc-handlers.test.ts
+++ b/tests/unit/electron/ipc-handlers.test.ts
@@ -565,6 +565,14 @@ describe("registerIpcHandlers", () => {
       expect(mockTunnelManager.start).toHaveBeenCalledWith(3000, { hostname: "custom.host.com" });
     });
 
+    it("prefers explicit tunnelConfig over settings", async () => {
+      mockApp.isPackaged = false;
+      mockLoadSettings.mockReturnValue({ tunnelConfig: { hostname: "old.host.com" } });
+      await getHandler("tunnel:start")(fakeEvent, 3000, { hostname: "new.host.com" });
+      expect(mockTunnelManager.start).toHaveBeenCalledWith(3000, { hostname: "new.host.com" });
+      expect(mockLoadSettings).not.toHaveBeenCalled();
+    });
+
     it("passes undefined tunnelConfig when settings has none", async () => {
       mockApp.isPackaged = false;
       mockLoadSettings.mockReturnValue({ otherSetting: true });

--- a/tests/unit/electron/services/tunnel-manager.test.ts
+++ b/tests/unit/electron/services/tunnel-manager.test.ts
@@ -418,6 +418,26 @@ describe("TunnelManager", () => {
       expect(tunnelManager.getInfo().status).toBe("running");
       expect(tunnelManager.getInfo().url).toBe(infoBefore.url);
     });
+
+    it("ignores quick tunnel URLs in named tunnel output", async () => {
+      await tunnelManager.start(3000, { hostname: "codemux.example.com" });
+
+      mockProcess.stderr.emit(
+        "data",
+        Buffer.from("Visit https://random.trycloudflare.com for status"),
+      );
+
+      expect(tunnelManager.getInfo().url).toBe("https://codemux.example.com");
+      expect(tunnelManager.getInfo().status).toBe("starting");
+
+      mockProcess.stderr.emit(
+        "data",
+        Buffer.from("Registered tunnel connection https://random.trycloudflare.com"),
+      );
+
+      expect(tunnelManager.getInfo().url).toBe("https://codemux.example.com");
+      expect(tunnelManager.getInfo().status).toBe("running");
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -476,36 +496,31 @@ describe("TunnelManager", () => {
   });
 
   // -------------------------------------------------------------------------
-  // start() — hostname but no credentials (fallback to quick tunnel)
+  // start() — hostname but no credentials
   // -------------------------------------------------------------------------
 
   describe("start() - hostname but no credentials", () => {
-    it("falls back to quick tunnel when no credentials found", async () => {
-      // detectTunnelId returns null
+    it("returns error when .cloudflared directory is missing", async () => {
       mockExistsSync.mockReturnValue(false);
 
-      await tunnelManager.start(3000, { hostname: "codemux.example.com" });
+      const info = await tunnelManager.start(3000, { hostname: "codemux.example.com" });
 
-      // Should use quick tunnel args, not named tunnel args
-      expect(mockSpawn).toHaveBeenCalledWith("cloudflared", [
-        "tunnel",
-        "--url",
-        "http://localhost:3000",
-      ]);
+      expect(info.status).toBe("error");
+      expect(info.errorCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
+      expect(mockSpawn).not.toHaveBeenCalled();
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
 
-    it("falls back to quick tunnel when .cloudflared dir exists but has no creds", async () => {
+    it("returns error when .cloudflared dir exists but has no creds", async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue(["config.yml"]);
 
-      await tunnelManager.start(3000, { hostname: "codemux.example.com" });
+      const info = await tunnelManager.start(3000, { hostname: "codemux.example.com" });
 
-      expect(mockSpawn).toHaveBeenCalledWith("cloudflared", [
-        "tunnel",
-        "--url",
-        "http://localhost:3000",
-      ]);
+      expect(info.status).toBe("error");
+      expect(info.errorCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
+      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/electron/services/tunnel-manager.test.ts
+++ b/tests/unit/electron/services/tunnel-manager.test.ts
@@ -500,27 +500,50 @@ describe("TunnelManager", () => {
   // -------------------------------------------------------------------------
 
   describe("start() - hostname but no credentials", () => {
-    it("returns error when .cloudflared directory is missing", async () => {
+    it("falls back to quick tunnel with warning when .cloudflared directory is missing", async () => {
       mockExistsSync.mockReturnValue(false);
 
       const info = await tunnelManager.start(3000, { hostname: "codemux.example.com" });
 
-      expect(info.status).toBe("error");
-      expect(info.errorCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
-      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(info.status).toBe("starting");
+      expect(info.warningCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
+      expect(mockSpawn).toHaveBeenCalledWith("cloudflared", [
+        "tunnel",
+        "--url",
+        "http://localhost:3000",
+      ]);
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
 
-    it("returns error when .cloudflared dir exists but has no creds", async () => {
+    it("falls back to quick tunnel with warning when .cloudflared dir exists but has no creds", async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue(["config.yml"]);
 
       const info = await tunnelManager.start(3000, { hostname: "codemux.example.com" });
 
-      expect(info.status).toBe("error");
-      expect(info.errorCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
-      expect(mockSpawn).not.toHaveBeenCalled();
+      expect(info.status).toBe("starting");
+      expect(info.warningCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
+      expect(mockSpawn).toHaveBeenCalledWith("cloudflared", [
+        "tunnel",
+        "--url",
+        "http://localhost:3000",
+      ]);
       expect(mockWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it("preserves missing credentials warning after quick tunnel URL is parsed", async () => {
+      mockExistsSync.mockReturnValue(false);
+
+      await tunnelManager.start(3000, { hostname: "codemux.example.com" });
+      mockProcess.stdout.emit(
+        "data",
+        Buffer.from("https://fallback.trycloudflare.com"),
+      );
+
+      const info = tunnelManager.getInfo();
+      expect(info.status).toBe("running");
+      expect(info.url).toBe("https://fallback.trycloudflare.com");
+      expect(info.warningCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
     });
   });
 

--- a/tests/unit/electron/services/tunnel-manager.test.ts
+++ b/tests/unit/electron/services/tunnel-manager.test.ts
@@ -500,50 +500,30 @@ describe("TunnelManager", () => {
   // -------------------------------------------------------------------------
 
   describe("start() - hostname but no credentials", () => {
-    it("falls back to quick tunnel with warning when .cloudflared directory is missing", async () => {
+    it("returns error when .cloudflared directory is missing", async () => {
       mockExistsSync.mockReturnValue(false);
 
       const info = await tunnelManager.start(3000, { hostname: "codemux.example.com" });
 
-      expect(info.status).toBe("starting");
-      expect(info.warningCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
-      expect(mockSpawn).toHaveBeenCalledWith("cloudflared", [
-        "tunnel",
-        "--url",
-        "http://localhost:3000",
-      ]);
+      expect(info.status).toBe("error");
+      expect(info.errorCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
+      expect(info.error).toContain("~/.cloudflared/<tunnel-id>.json");
+      expect(info.error).toContain("clear the custom domain");
+      expect(mockSpawn).not.toHaveBeenCalled();
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
 
-    it("falls back to quick tunnel with warning when .cloudflared dir exists but has no creds", async () => {
+    it("returns error when .cloudflared dir exists but has no creds", async () => {
       mockExistsSync.mockReturnValue(true);
       mockReaddirSync.mockReturnValue(["config.yml"]);
 
       const info = await tunnelManager.start(3000, { hostname: "codemux.example.com" });
 
-      expect(info.status).toBe("starting");
-      expect(info.warningCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
-      expect(mockSpawn).toHaveBeenCalledWith("cloudflared", [
-        "tunnel",
-        "--url",
-        "http://localhost:3000",
-      ]);
+      expect(info.status).toBe("error");
+      expect(info.errorCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
+      expect(info.error).toContain("cloudflared tunnel create <name>");
+      expect(mockSpawn).not.toHaveBeenCalled();
       expect(mockWriteFileSync).not.toHaveBeenCalled();
-    });
-
-    it("preserves missing credentials warning after quick tunnel URL is parsed", async () => {
-      mockExistsSync.mockReturnValue(false);
-
-      await tunnelManager.start(3000, { hostname: "codemux.example.com" });
-      mockProcess.stdout.emit(
-        "data",
-        Buffer.from("https://fallback.trycloudflare.com"),
-      );
-
-      const info = tunnelManager.getInfo();
-      expect(info.status).toBe("running");
-      expect(info.url).toBe("https://fallback.trycloudflare.com");
-      expect(info.warningCode).toBe("NAMED_TUNNEL_NO_CREDENTIALS");
     });
   });
 

--- a/tests/unit/src/lib/settings.test.ts
+++ b/tests/unit/src/lib/settings.test.ts
@@ -70,12 +70,42 @@ describe('settings', () => {
       };
 
       expect(getSetting('theme')).toBe('light');
-      
+
       saveSetting('theme', 'system');
       expect(saveMock).toHaveBeenCalledWith({ theme: 'system' });
       expect(getSetting('theme')).toBe('system');
       // Also saved to localStorage as secondary cache
       expect(localStorage.getItem('settings:theme')).toBe(JSON.stringify('system'));
+    });
+
+    it('waits for Electron settings save before resolving', async () => {
+      vi.mocked(isElectron).mockReturnValue(true);
+      let resolveSave!: () => void;
+      const savePromise = new Promise<{ success: boolean }>((resolve) => {
+        resolveSave = () => resolve({ success: true });
+      });
+      const saveMock = vi.fn(() => savePromise);
+      (window as any).electronAPI = {
+        settings: {
+          cache: {},
+          save: saveMock,
+        },
+      };
+
+      let resolved = false;
+      const promise = saveSetting('tunnelConfig', { hostname: 'codemux.example.com' }).then(() => {
+        resolved = true;
+      });
+
+      expect(saveMock).toHaveBeenCalledWith({ tunnelConfig: { hostname: 'codemux.example.com' } });
+      expect(localStorage.getItem('settings:tunnelConfig')).toBe(JSON.stringify({ hostname: 'codemux.example.com' }));
+
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+
+      resolveSave();
+      await promise;
+      expect(resolved).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- Pass the latest named tunnel hostname directly through Electron IPC when starting Cloudflare Tunnel.
- Block fixed custom-domain startup when the required `~/.cloudflared/<tunnel-id>.json` named tunnel credential is missing, with a clear setup/error message instead of silently falling back to a random quick tunnel URL.
- Add localized UI messaging and regression coverage for custom-domain startup behavior.

## Test plan
- [x] `bun run test:unit -- tests/unit/electron/services/tunnel-manager.test.ts tests/unit/electron/ipc-handlers.test.ts tests/unit/src/lib/settings.test.ts`
- [x] `bun run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)