### PR TITLE
Fix wide response tables and Feishu cards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Thumbs.db
 *.swp
 *.swo
 .halo/
+.claude/
 
 # Logs
 *.log

--- a/electron/main/channels/feishu/feishu-transport.ts
+++ b/electron/main/channels/feishu/feishu-transport.ts
@@ -34,9 +34,10 @@ export class FeishuTransport implements MessageTransport {
     }
   }
 
-  /** Send markdown wrapped in a minimal Feishu Interactive Card. */
+  /** Send markdown wrapped in a Feishu Interactive Card with mobile-friendly configuration. */
   async sendMarkdown(chatId: string, markdown: string): Promise<string> {
     const card = JSON.stringify({
+      config: { wide_screen_mode: true },
       elements: [{ tag: "markdown", content: markdown }],
     });
     return this.sendRichContent(chatId, card);

--- a/src/components/SessionTurn.module.css
+++ b/src/components/SessionTurn.module.css
@@ -244,6 +244,7 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  min-width: 0;
   padding: 0.75rem;
   border: 1px solid rgba(148, 163, 184, 0.12);
   border-radius: 0.875rem;
@@ -276,6 +277,9 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
   padding: 0.75rem 1rem;
   border: 1px solid #E2E8F0;
   border-radius: 1rem;
@@ -328,6 +332,8 @@
 }
 
 .responseContent {
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* ─── Compacting Turn ─── */

--- a/src/components/share/content-markdown.module.css
+++ b/src/components/share/content-markdown.module.css
@@ -13,6 +13,8 @@
 
   [data-slot="markdown"] {
     display: -webkit-box;
+    min-width: 0;
+    max-width: 100%;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 3;
     line-clamp: 3;
@@ -164,6 +166,7 @@
     table {
       border-collapse: collapse;
       width: 100%;
+      max-width: 100%;
       display: block;
       overflow-x: auto;
       -webkit-overflow-scrolling: touch;
@@ -182,6 +185,8 @@
       border: 1px solid var(--sl-color-border);
       padding: 0.5rem 0.75rem;
       text-align: left;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
 
     th {

--- a/tests/unit/electron/channels/feishu/feishu-transport.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-transport.test.ts
@@ -184,9 +184,10 @@ describe("FeishuTransport", () => {
       expect(callArgs.data.receive_id).toBe("chat-1");
       expect(callArgs.data.msg_type).toBe("interactive");
 
-      // The content should be JSON with elements containing markdown tag
+      // The content should be JSON with elements containing markdown tag and wide_screen_mode config
       const content = JSON.parse(callArgs.data.content);
       expect(content).toEqual({
+        config: { wide_screen_mode: true },
         elements: [{ tag: "markdown", content: "**bold** text" }],
       });
     });
@@ -227,6 +228,7 @@ describe("FeishuTransport", () => {
       const cardArg = spy.mock.calls[0][1];
       const parsed = JSON.parse(cardArg);
       expect(parsed).toEqual({
+        config: { wide_screen_mode: true },
         elements: [{ tag: "markdown", content: "hello" }],
       });
     });


### PR DESCRIPTION
## Summary
- Constrain assistant response cards and markdown containers so wide tables stay inside the chat column.
- Allow long table cell content to wrap while preserving table-level horizontal scrolling.
- Enable wide-screen Feishu markdown cards and ignore local `.claude/` artifacts.

## Test plan
- [x] `bun run test:unit tests/unit/electron/channels/feishu/feishu-transport.test.ts`
- [x] Manually verified a wide markdown table with long URLs and long unbroken tokens stays within the response bubble.
- [ ] `bun run typecheck` currently fails on existing `electron/main/engines/opencode/converters.ts` type errors unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)