### PR TITLE
fix(claude): route AskUserQuestion to question UI and fix answer payload

### DIFF
--- a/electron/main/engines/claude/index.ts
+++ b/electron/main/engines/claude/index.ts
@@ -117,7 +117,7 @@ interface PendingPermission {
 }
 
 interface PendingQuestion {
-  resolve: (answer: string) => void;
+  resolve: (answers: string[][]) => void;
   question: UnifiedQuestion;
 }
 
@@ -653,7 +653,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     }
     for (const [id, pending] of this.pendingQuestions) {
       if (pending.question.sessionId === sessionId) {
-        pending.resolve("Session deleted");
+        pending.resolve([["Session deleted"]]);
         this.pendingQuestions.delete(id);
       }
     }
@@ -956,7 +956,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     // Reject pending questions/permissions for this session so the UI unblocks
     for (const [id, pending] of this.pendingQuestions) {
       if (pending.question.sessionId === sessionId) {
-        pending.resolve("");
+        pending.resolve([]);
         this.pendingQuestions.delete(id);
       }
     }
@@ -1390,6 +1390,11 @@ export class ClaudeCodeAdapter extends EngineAdapter {
         return this.handleExitPlanMode(sessionId, input, options);
       }
 
+      // --- AskUserQuestion: route through the question UI, not permission UI ---
+      if (toolName === "AskUserQuestion") {
+        return this.handleAskUserQuestion(sessionId, input, options);
+      }
+
       return this.handleToolPermission(sessionId, toolName, input, options);
     };
   }
@@ -1539,7 +1544,8 @@ export class ClaudeCodeAdapter extends EngineAdapter {
 
     return new Promise<PermissionResult>((resolve) => {
       this.pendingQuestions.set(questionId, {
-        resolve: (answer: string) => {
+        resolve: (perQuestion: string[][]) => {
+          const answer = (perQuestion[0] ?? []).filter((s) => s && s.length > 0).join("\n");
           const trimmed = answer.trim();
           const lower = trimmed.toLowerCase();
           const approved =
@@ -1651,11 +1657,17 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     return new Promise<PermissionResult>((resolve) => {
       // Store pending question with a resolver that converts to PermissionResult
       this.pendingQuestions.set(questionId, {
-        resolve: (answer: string) => {
-          // Convert answer back to updatedInput with answers field
+        resolve: (perQuestion: string[][]) => {
+          // SDK contract (AskUserQuestionOutput.answers): keyed by question text,
+          // value is the answer string (multi-select joined by ", ").
+          const answersObj: Record<string, string> = {};
+          rawQuestions.forEach((q, i) => {
+            const parts = (perQuestion[i] ?? []).filter((s) => s && s.length > 0);
+            answersObj[q.question] = parts.join(", ");
+          });
           resolve({
             behavior: "allow",
-            updatedInput: { ...input, answers: { "0": answer } },
+            updatedInput: { ...input, answers: answersObj },
           });
         },
         question,
@@ -1699,9 +1711,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
 
     this.pendingQuestions.delete(questionId);
 
-    // Combine all answers (selected options + custom text) into one string
-    const answer = (answers[0] ?? []).join("\n") || "";
-    pending.resolve(answer);
+    pending.resolve(answers);
 
     this.emit("question.replied", { questionId, answers });
   }
@@ -1711,7 +1721,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     if (!pending) return;
 
     this.pendingQuestions.delete(questionId);
-    pending.resolve(""); // Empty answer = rejection
+    pending.resolve([]); // Empty answers = rejection
   }
 
   getPendingQuestions(sessionId?: string): UnifiedQuestion[] {
@@ -3552,7 +3562,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
 
   private rejectAllPendingQuestions(reason: string): void {
     for (const [_id, pending] of this.pendingQuestions) {
-      pending.resolve("");
+      pending.resolve([]);
     }
     this.pendingQuestions.clear();
   }

--- a/electron/main/engines/claude/index.ts
+++ b/electron/main/engines/claude/index.ts
@@ -653,7 +653,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
     }
     for (const [id, pending] of this.pendingQuestions) {
       if (pending.question.sessionId === sessionId) {
-        pending.resolve([["Session deleted"]]);
+        pending.resolve([]);
         this.pendingQuestions.delete(id);
       }
     }
@@ -1658,6 +1658,15 @@ export class ClaudeCodeAdapter extends EngineAdapter {
       // Store pending question with a resolver that converts to PermissionResult
       this.pendingQuestions.set(questionId, {
         resolve: (perQuestion: string[][]) => {
+          // Empty array = cancellation/rejection (cleanup paths, abort, dismiss).
+          // Treat as a denial so the SDK doesn't get a malformed empty tool result.
+          const hasAnyAnswer = perQuestion.some((a) =>
+            (a ?? []).some((s) => s && s.length > 0),
+          );
+          if (!hasAnyAnswer) {
+            resolve({ behavior: "deny", message: "Question cancelled by user" });
+            return;
+          }
           // SDK contract (AskUserQuestionOutput.answers): keyed by question text,
           // value is the answer string (multi-select joined by ", ").
           const answersObj: Record<string, string> = {};

--- a/tests/unit/electron/engines/claude/index.test.ts
+++ b/tests/unit/electron/engines/claude/index.test.ts
@@ -327,7 +327,7 @@ describe("ClaudeCodeAdapter", () => {
       expect((adapter as any).pendingPermissions.has("perm-1")).toBe(false);
     });
 
-    it("resolves pending questions with empty string", async () => {
+    it("resolves pending questions with empty array", async () => {
       seedSession(adapter, "cs_1");
       const resolve = vi.fn();
       (adapter as any).pendingQuestions.set("q-1", {
@@ -336,7 +336,7 @@ describe("ClaudeCodeAdapter", () => {
       });
 
       await adapter.deleteSession("cs_1");
-      expect(resolve).toHaveBeenCalledWith("Session deleted");
+      expect(resolve).toHaveBeenCalledWith([]);
       expect((adapter as any).pendingQuestions.has("q-1")).toBe(false);
     });
 
@@ -1434,10 +1434,10 @@ describe("ClaudeCodeAdapter", () => {
       return resolve;
     }
 
-    it("resolves question with joined first answer array", async () => {
+    it("forwards the full per-question answers array to the resolver", async () => {
       const resolve = seedPendingQuestion(adapter, "q-1");
       await adapter.replyQuestion("q-1", [["Approve", "extra note"]]);
-      expect(resolve).toHaveBeenCalledWith("Approve\nextra note");
+      expect(resolve).toHaveBeenCalledWith([["Approve", "extra note"]]);
     });
 
     it("removes question from pending map after reply", async () => {
@@ -1460,14 +1460,14 @@ describe("ClaudeCodeAdapter", () => {
   });
 
   describe("rejectQuestion()", () => {
-    it("resolves question with empty string", async () => {
+    it("resolves question with empty array", async () => {
       const resolve = vi.fn();
       (adapter as any).pendingQuestions.set("q-1", {
         resolve,
         question: { id: "q-1", sessionId: "cs_1" },
       });
       await adapter.rejectQuestion("q-1");
-      expect(resolve).toHaveBeenCalledWith("");
+      expect(resolve).toHaveBeenCalledWith([]);
       expect((adapter as any).pendingQuestions.has("q-1")).toBe(false);
     });
 
@@ -1493,7 +1493,7 @@ describe("ClaudeCodeAdapter", () => {
 
       // Get the question ID and reply
       const qId = [...(adapter as any).pendingQuestions.keys()][0];
-      (adapter as any).pendingQuestions.get(qId)!.resolve("approve");
+      (adapter as any).pendingQuestions.get(qId)!.resolve([["approve"]]);
 
       const result = await p;
       expect(result.behavior).toBe("allow");
@@ -1505,7 +1505,7 @@ describe("ClaudeCodeAdapter", () => {
       const p = (adapter as any).handleExitPlanMode("cs_1", {}, opts) as Promise<any>;
 
       const qId = [...(adapter as any).pendingQuestions.keys()][0];
-      (adapter as any).pendingQuestions.get(qId)!.resolve("同意");
+      (adapter as any).pendingQuestions.get(qId)!.resolve([["同意"]]);
 
       const result = await p;
       expect(result.behavior).toBe("allow");
@@ -1517,7 +1517,7 @@ describe("ClaudeCodeAdapter", () => {
       const p = (adapter as any).handleExitPlanMode("cs_1", {}, opts) as Promise<any>;
 
       const qId = [...(adapter as any).pendingQuestions.keys()][0];
-      (adapter as any).pendingQuestions.get(qId)!.resolve("1");
+      (adapter as any).pendingQuestions.get(qId)!.resolve([["1"]]);
 
       const result = await p;
       expect(result.behavior).toBe("allow");
@@ -1529,7 +1529,7 @@ describe("ClaudeCodeAdapter", () => {
       const p = (adapter as any).handleExitPlanMode("cs_1", {}, opts) as Promise<any>;
 
       const qId = [...(adapter as any).pendingQuestions.keys()][0];
-      (adapter as any).pendingQuestions.get(qId)!.resolve("0");
+      (adapter as any).pendingQuestions.get(qId)!.resolve([["0"]]);
 
       const result = await p;
       expect(result.behavior).toBe("allow");
@@ -1541,7 +1541,7 @@ describe("ClaudeCodeAdapter", () => {
       const p = (adapter as any).handleExitPlanMode("cs_1", {}, opts) as Promise<any>;
 
       const qId = [...(adapter as any).pendingQuestions.keys()][0];
-      (adapter as any).pendingQuestions.get(qId)!.resolve("reject, needs more work");
+      (adapter as any).pendingQuestions.get(qId)!.resolve([["reject, needs more work"]]);
 
       const result = await p;
       expect(result.behavior).toBe("deny");
@@ -1557,7 +1557,7 @@ describe("ClaudeCodeAdapter", () => {
       const p = (adapter as any).handleExitPlanMode("cs_1", {}, opts) as Promise<any>;
 
       const qId = [...(adapter as any).pendingQuestions.keys()][0];
-      (adapter as any).pendingQuestions.get(qId)!.resolve("approve");
+      (adapter as any).pendingQuestions.get(qId)!.resolve([["approve"]]);
       await p;
 
       expect(asked).toHaveLength(1);
@@ -3157,7 +3157,7 @@ describe("ClaudeCodeAdapter", () => {
 
       await adapter.cancelMessage("cs_1");
 
-      expect(resolveQ).toHaveBeenCalledWith("");
+      expect(resolveQ).toHaveBeenCalledWith([]);
       expect((adapter as any).pendingQuestions.has("q-cancel")).toBe(false);
     });
 


### PR DESCRIPTION
## Summary

Two bugs in the Claude engine adapter around `AskUserQuestion`:

1. **AskUserQuestion was rendering as an empty permission dialog.**
   `createCanUseTool` only intercepted `ExitPlanMode`; everything else fell through to `handleToolPermission`, which extracts details from `input.command/file_path/url/pattern`. `AskUserQuestion`'s payload is `input.questions`, so the structured details came out empty and the user only saw three Allow/Deny buttons with no question text.

2. **Answer payload sent back to the SDK was malformed.**
   - `replyQuestion` only forwarded `answers[0]`, dropping every question past the first.
   - The resolver hardcoded `answers: { "0": ... }`, but the SDK's `AskUserQuestionOutput.answers` contract is `{ [questionText]: string }` (multi-select joined by `", "`). The mismatched key meant the SDK saw no answers at all and returned an empty `tool_result` to the model.

## Changes (single file: `electron/main/engines/claude/index.ts`)

- `createCanUseTool`: add an `AskUserQuestion` branch that routes to the existing `handleAskUserQuestion`.
- `PendingQuestion.resolve` signature: `(answer: string)` → `(answers: string[][])` so the resolver receives every question's answers.
- `handleAskUserQuestion` resolver: build `{ [question.question]: parts.join(", ") }` to match the SDK contract.
- `handleExitPlanMode` resolver: flatten `answers[0]` to a string before approve/reject keyword check.
- `replyQuestion` and the three cleanup paths (session delete, cancel, stop): updated to the new `string[][]` signature.

## Test plan

- [x] `npm run typecheck` passes
- [x] Verified end-to-end with the running Electron app: sent a 2-question AskUserQuestion (one single-select, one multi-select with custom text), confirmed the question UI renders and answers come back correctly keyed by question text with multi-select joined by `", "`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)