### PR TITLE
feat(server-dev): server:dev:isolated — dev:isolated parity for the headless server

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start": "bun scripts/start.ts",
     "server:init": "bash ./scripts/server-init.sh",
     "server:dev": "bash ./scripts/server-dev.sh start --foreground",
+    "server:dev:isolated": "cross-env CODEMUX_DEV_ISOLATED=1 bun scripts/dev-isolated.ts --server",
     "server:up": "bash ./scripts/server-dev.sh start --replace",
     "server:tunnel": "bash ./scripts/server-dev.sh start --replace --tunnel",
     "server:down": "bash ./scripts/server-dev.sh stop",

--- a/scripts/dev-isolated.ts
+++ b/scripts/dev-isolated.ts
@@ -275,6 +275,34 @@ function writePortsFile(devRoot: string, plan: PortPlan): void {
   fs.writeFileSync(path.join(devRoot, PORTS_FILE), `${JSON.stringify(data, null, 2)}\n`, "utf-8");
 }
 
+export interface SpawnTarget {
+  cmd: string;
+  args: string[];
+}
+
+/**
+ * Decide which child command to spawn under the isolated port reservation.
+ *
+ * - `--server`: spawn the headless server wrapper (`scripts/server-dev.sh
+ *   start --foreground`), which inherits `CODEMUX_DEV_ISOLATED=1` +
+ *   `CODEMUX_PORT_OFFSET=<N>` from us and feeds them into `bun run dev`. This
+ *   is what `server:dev:isolated` ships.
+ * - default: spawn `bun run dev` directly. This is the original `dev:isolated`
+ *   behaviour for the Electron desktop loop.
+ *
+ * Kept as a pure function so the dispatch logic is unit-testable without
+ * actually spawning a child.
+ */
+export function resolveSpawnTarget(args: readonly string[], projectRootPath: string): SpawnTarget {
+  if (args.includes("--server")) {
+    return {
+      cmd: "bash",
+      args: [path.join(projectRootPath, "scripts/server-dev.sh"), "start", "--foreground"],
+    };
+  }
+  return { cmd: "bun", args: ["run", "dev"] };
+}
+
 async function main(): Promise<void> {
   const devRoot = path.join(projectRoot, DEV_ISOLATED_DIR);
   const reservation = await allocatePortReservation(devRoot);
@@ -283,11 +311,17 @@ async function main(): Promise<void> {
 
   process.on("exit", () => reservation.release());
 
+  const target = resolveSpawnTarget(process.argv.slice(2), projectRoot);
+  const isServerMode = target.cmd === "bash";
+
   console.log(`CodeMux isolated dev data: ${devRoot}`);
   console.log(`CodeMux port offset: ${plan.portOffset}`);
   console.log(`CodeMux web port: ${plan.ports.web}`);
+  if (isServerMode) {
+    console.log(`CodeMux mode: headless server (via ${target.args[0]})`);
+  }
 
-  const child = spawn("bun", ["run", "dev"], {
+  const child = spawn(target.cmd, target.args, {
     cwd: projectRoot,
     env: {
       ...process.env,

--- a/scripts/server-dev.sh
+++ b/scripts/server-dev.sh
@@ -3,7 +3,24 @@ set -euo pipefail
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_DIR=$(cd -- "${SCRIPT_DIR}/.." && pwd)
-STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/codemux-server"
+
+export PATH="$HOME/.bun/bin:$HOME/.opencode/bin:$PATH"
+
+# State dir is resolved by scripts/state-dir.ts so this script,
+# scripts/tunnel-manager.ts, and any future consumer share one implementation.
+#
+# Two modes, decided by `CODEMUX_DEV_ISOLATED`:
+#   - unset / "0": machine-global single-instance dir
+#     (`<XDG_STATE_HOME>/codemux-server/`). Starting `server:up` in worktree A
+#     and checking `server:status` from worktree B both see the same server.
+#   - "1": per-repo isolated dir (`<repoDir>/.codemux-dev/server/`). Mirrors
+#     `dev:isolated`'s semantics — used by the `server:dev:isolated` script,
+#     which spawns this wrapper after allocating a port offset.
+command -v bun >/dev/null 2>&1 || {
+  printf '[31m[x][0m Missing required command: bun\n' >&2
+  exit 1
+}
+STATE_DIR=$(bun "$SCRIPT_DIR/state-dir.ts" "$REPO_DIR")
 APP_LOG="$STATE_DIR/dev.log"
 TUNNEL_LOG="$STATE_DIR/tunnel.log"
 APP_PID_FILE="$STATE_DIR/dev.pid"
@@ -12,8 +29,6 @@ LOCAL_URL_FILE="$STATE_DIR/local-url"
 TUNNEL_URL_FILE="$STATE_DIR/tunnel-url"
 XVFB_SCREEN="${CODEMUX_XVFB_SCREEN:-1280x720x24}"
 DEFAULT_TIMEOUT="${CODEMUX_SERVER_START_TIMEOUT:-90}"
-
-export PATH="$HOME/.bun/bin:$HOME/.opencode/bin:$PATH"
 
 usage() {
   cat <<'EOF'
@@ -275,7 +290,7 @@ start_foreground() {
   printf '    bun run server:access-requests
 '
   cd "$REPO_DIR"
-  exec env CODEMUX_DISABLE_COPILOT_DBUS=1 CODEMUX_SERVER_MODE=1 \
+  exec env CODEMUX_DISABLE_COPILOT_DBUS=1 CODEMUX_SERVER_MODE=1 CODEMUX_SERVER_STATE_DIR="$STATE_DIR" \
     dbus-run-session -- xvfb-run --auto-servernum --server-args="-screen 0 $XVFB_SCREEN" bun run dev
 }
 
@@ -286,7 +301,7 @@ start_background() {
   rm -f "$LOCAL_URL_FILE" "$TUNNEL_URL_FILE"
   : > "$APP_LOG"
 
-  setsid bash -lc "export PATH=\"$HOME/.bun/bin:$HOME/.opencode/bin:\$PATH\"; export CODEMUX_DISABLE_COPILOT_DBUS=1; export CODEMUX_SERVER_MODE=1; cd \"$REPO_DIR\"; exec dbus-run-session -- xvfb-run --auto-servernum --server-args='-screen 0 $XVFB_SCREEN' bun run dev" > "$APP_LOG" 2>&1 &
+  setsid bash -lc "export PATH=\"$HOME/.bun/bin:$HOME/.opencode/bin:\$PATH\"; export CODEMUX_DISABLE_COPILOT_DBUS=1; export CODEMUX_SERVER_MODE=1; export CODEMUX_SERVER_STATE_DIR=\"$STATE_DIR\"; cd \"$REPO_DIR\"; exec dbus-run-session -- xvfb-run --auto-servernum --server-args='-screen 0 $XVFB_SCREEN' bun run dev" > "$APP_LOG" 2>&1 &
   local app_pid=$!
   printf '%s
 ' "$app_pid" > "$APP_PID_FILE"

--- a/scripts/state-dir.ts
+++ b/scripts/state-dir.ts
@@ -1,0 +1,97 @@
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SERVER_DIR_NAME = "codemux-server";
+const DEV_ISOLATED_DIR = ".codemux-dev";
+const DEV_ISOLATED_SERVER_SUBDIR = "server";
+
+export interface BaseOptions {
+  /** Environment overrides, primarily for testability. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+  /** Override `os.homedir()`, primarily for testability. */
+  homedir?: string;
+}
+
+export interface ServerStateDirOptions extends BaseOptions {
+  /** Absolute path to the repository root. */
+  repoDir: string;
+  /**
+   * If true, return the per-repo isolated server state dir
+   * (`<repoDir>/.codemux-dev/server/`). If false or omitted, return the
+   * machine-global state dir (`<XDG_STATE_HOME>/codemux-server/`) so the
+   * single-instance `bun run server:up` flow stays observable from any
+   * worktree.
+   */
+  isolated?: boolean;
+}
+
+function resolveHome(options: BaseOptions): string {
+  if (options.env?.HOME && options.env.HOME.length > 0) return options.env.HOME;
+  if (options.homedir) return options.homedir;
+  return os.homedir();
+}
+
+/**
+ * Machine-global server state root: `<XDG_STATE_HOME or ~/.local/state>/codemux-server`.
+ *
+ * Used by the default (non-isolated) `server:up` flow so the server presents
+ * single-instance semantics across worktrees: starting it in one worktree and
+ * checking its status from another both hit the same set of pid/log/url files.
+ */
+export function getGlobalServerStateRoot(options: BaseOptions = {}): string {
+  const env = options.env ?? process.env;
+  const xdg = env.XDG_STATE_HOME;
+  const base = xdg && xdg.length > 0 ? xdg : path.join(resolveHome(options), ".local", "state");
+  return path.join(base, SERVER_DIR_NAME);
+}
+
+/**
+ * Per-repo isolated server state dir: `<repoDir>/.codemux-dev/server`.
+ *
+ * Used by the `server:dev:isolated` flow (via `dev-isolated.ts --server`),
+ * which mirrors `dev:isolated`'s "every worktree is its own world" semantics
+ * to the headless server. Lives under the same `.codemux-dev/` root as
+ * userData/sessionData/logs/ports.json so a single `git clean -fdx`-style
+ * gesture wipes the whole isolated instance.
+ */
+export function getIsolatedServerStateDir(repoDir: string): string {
+  return path.join(path.resolve(repoDir), DEV_ISOLATED_DIR, DEV_ISOLATED_SERVER_SUBDIR);
+}
+
+/**
+ * Resolve the server's state directory based on the mode.
+ *
+ * Single source of truth for `scripts/server-dev.sh` (via its CLI entry
+ * point) and `scripts/tunnel-manager.ts` (which imports the function
+ * directly). Nothing else should hard-code the path.
+ */
+export function resolveServerStateDir(options: ServerStateDirOptions): string {
+  if (options.isolated) {
+    return getIsolatedServerStateDir(options.repoDir);
+  }
+  return getGlobalServerStateRoot(options);
+}
+
+/**
+ * Read the isolated flag from a CLI args list, an env bag, or both.
+ * - Explicit `--isolated` / `--global` flags win.
+ * - Otherwise, `CODEMUX_DEV_ISOLATED === "1"` decides.
+ */
+export function readIsolatedFromArgsAndEnv(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (args.includes("--isolated")) return true;
+  if (args.includes("--global")) return false;
+  return env.CODEMUX_DEV_ISOLATED === "1";
+}
+
+const currentFile = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFile) {
+  const args = process.argv.slice(2);
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const repoDir = positional[0] ?? process.cwd();
+  const isolated = readIsolatedFromArgsAndEnv(args, process.env);
+  process.stdout.write(resolveServerStateDir({ repoDir, isolated }));
+}

--- a/scripts/tunnel-manager.ts
+++ b/scripts/tunnel-manager.ts
@@ -1,7 +1,7 @@
 import { spawn, ChildProcess } from "child_process";
 import fs from "fs";
-import os from "os";
 import path from "path";
+import { resolveServerStateDir } from "./state-dir";
 
 interface TunnelInfo {
   url: string;
@@ -21,9 +21,25 @@ class TunnelManager {
     url: "",
     status: "stopped",
   };
+  private loggedStateDir = false;
 
   private getStateDir(): string {
-    return path.join(process.env.XDG_STATE_HOME || path.join(os.homedir(), ".local", "state"), "codemux-server");
+    const envOverride = process.env.CODEMUX_SERVER_STATE_DIR;
+    if (envOverride && envOverride.length > 0) {
+      this.logStateDirOnce(envOverride, "CODEMUX_SERVER_STATE_DIR");
+      return envOverride;
+    }
+
+    const isolated = process.env.CODEMUX_DEV_ISOLATED === "1";
+    const dir = resolveServerStateDir({ repoDir: process.cwd(), isolated });
+    this.logStateDirOnce(dir, isolated ? "isolated <cwd>/.codemux-dev/server" : "global <XDG_STATE_HOME>/codemux-server");
+    return dir;
+  }
+
+  private logStateDirOnce(dir: string, source: string): void {
+    if (this.loggedStateDir) return;
+    this.loggedStateDir = true;
+    console.log(`[Tunnel] External tunnel state dir resolved to ${dir} (via ${source})`);
   }
 
   private getExternalTunnelPidFile(): string {

--- a/tests/unit/scripts/dev-isolated.test.ts
+++ b/tests/unit/scripts/dev-isolated.test.ts
@@ -1,5 +1,6 @@
+import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildPortPlan } from "../../../scripts/dev-isolated";
+import { buildPortPlan, resolveSpawnTarget } from "../../../scripts/dev-isolated";
 
 describe("dev-isolated script", () => {
   it("builds an offset port plan", () => {
@@ -38,5 +39,35 @@ describe("dev-isolated script", () => {
       CODEMUX_WEB_PORT: "9100",
       CODEMUX_GATEWAY_PORT: "9100",
     })).toThrow("CODEMUX_GATEWAY_PORT and CODEMUX_WEB_PORT both resolve to port 9100");
+  });
+});
+
+describe("resolveSpawnTarget", () => {
+  const projectRoot = "/repo";
+
+  it("defaults to `bun run dev` when no --server flag is passed", () => {
+    expect(resolveSpawnTarget([], projectRoot)).toEqual({
+      cmd: "bun",
+      args: ["run", "dev"],
+    });
+  });
+
+  it("switches to the headless server wrapper when --server is present", () => {
+    expect(resolveSpawnTarget(["--server"], projectRoot)).toEqual({
+      cmd: "bash",
+      args: [path.join("/repo", "scripts/server-dev.sh"), "start", "--foreground"],
+    });
+  });
+
+  it("ignores unrelated args in the dev path", () => {
+    expect(resolveSpawnTarget(["--", "--unused-flag"], projectRoot)).toEqual({
+      cmd: "bun",
+      args: ["run", "dev"],
+    });
+  });
+
+  it("composes the server-dev.sh path relative to the supplied project root", () => {
+    const target = resolveSpawnTarget(["--server"], "/some/other/root");
+    expect(target.args[0]).toBe(path.join("/some/other/root", "scripts/server-dev.sh"));
   });
 });

--- a/tests/unit/scripts/state-dir.test.ts
+++ b/tests/unit/scripts/state-dir.test.ts
@@ -41,7 +41,7 @@ describe("getGlobalServerStateRoot", () => {
 describe("getIsolatedServerStateDir", () => {
   it("composes <repoDir>/.codemux-dev/server", () => {
     expect(getIsolatedServerStateDir("/home/dev/codemux")).toBe(
-      path.join("/home/dev/codemux", ".codemux-dev", "server"),
+      path.join(path.resolve("/home/dev/codemux"), ".codemux-dev", "server"),
     );
   });
 
@@ -53,7 +53,7 @@ describe("getIsolatedServerStateDir", () => {
 
   it("keeps the basename of the repo dir verbatim — no slugging", () => {
     const dir = getIsolatedServerStateDir("/tmp/CodeMux Worktree/X");
-    expect(dir).toBe(path.join("/tmp/CodeMux Worktree/X", ".codemux-dev", "server"));
+    expect(dir).toBe(path.join(path.resolve("/tmp/CodeMux Worktree/X"), ".codemux-dev", "server"));
   });
 });
 
@@ -73,7 +73,7 @@ describe("resolveServerStateDir", () => {
   it("returns the per-repo isolated dir when isolated is true", () => {
     expect(
       resolveServerStateDir({ repoDir: "/home/dev/codemux", isolated: true, env: { XDG_STATE_HOME: "/state" } }),
-    ).toBe(path.join("/home/dev/codemux", ".codemux-dev", "server"));
+    ).toBe(path.join(path.resolve("/home/dev/codemux"), ".codemux-dev", "server"));
   });
 
   it("ignores XDG_STATE_HOME when isolated is true — the dir lives in the repo", () => {

--- a/tests/unit/scripts/state-dir.test.ts
+++ b/tests/unit/scripts/state-dir.test.ts
@@ -1,0 +1,128 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  getGlobalServerStateRoot,
+  getIsolatedServerStateDir,
+  readIsolatedFromArgsAndEnv,
+  resolveServerStateDir,
+} from "../../../scripts/state-dir";
+
+describe("getGlobalServerStateRoot", () => {
+  it("uses XDG_STATE_HOME when set and non-empty", () => {
+    expect(getGlobalServerStateRoot({ env: { XDG_STATE_HOME: "/custom/state" } })).toBe(
+      path.join("/custom/state", "codemux-server"),
+    );
+  });
+
+  it("falls back to $HOME/.local/state when XDG_STATE_HOME is unset", () => {
+    expect(getGlobalServerStateRoot({ env: { HOME: "/home/test" } })).toBe(
+      path.join("/home/test", ".local", "state", "codemux-server"),
+    );
+  });
+
+  it("falls back to $HOME/.local/state when XDG_STATE_HOME is empty", () => {
+    expect(getGlobalServerStateRoot({ env: { XDG_STATE_HOME: "", HOME: "/home/test" } })).toBe(
+      path.join("/home/test", ".local", "state", "codemux-server"),
+    );
+  });
+
+  it("honours the explicit homedir override when HOME is unset", () => {
+    expect(getGlobalServerStateRoot({ env: {}, homedir: "/alt/home" })).toBe(
+      path.join("/alt/home", ".local", "state", "codemux-server"),
+    );
+  });
+
+  it("is path-stable regardless of the repo the caller is in", () => {
+    const env = { XDG_STATE_HOME: "/state" };
+    expect(getGlobalServerStateRoot({ env })).toBe(getGlobalServerStateRoot({ env }));
+  });
+});
+
+describe("getIsolatedServerStateDir", () => {
+  it("composes <repoDir>/.codemux-dev/server", () => {
+    expect(getIsolatedServerStateDir("/home/dev/codemux")).toBe(
+      path.join("/home/dev/codemux", ".codemux-dev", "server"),
+    );
+  });
+
+  it("resolves relative paths to absolute paths", () => {
+    expect(getIsolatedServerStateDir("some-rel")).toBe(
+      path.join(path.resolve("some-rel"), ".codemux-dev", "server"),
+    );
+  });
+
+  it("keeps the basename of the repo dir verbatim — no slugging", () => {
+    const dir = getIsolatedServerStateDir("/tmp/CodeMux Worktree/X");
+    expect(dir).toBe(path.join("/tmp/CodeMux Worktree/X", ".codemux-dev", "server"));
+  });
+});
+
+describe("resolveServerStateDir", () => {
+  it("returns the machine-global root when isolated is omitted (single-instance default)", () => {
+    expect(resolveServerStateDir({ repoDir: "/anywhere", env: { XDG_STATE_HOME: "/state" } })).toBe(
+      path.join("/state", "codemux-server"),
+    );
+  });
+
+  it("returns the machine-global root when isolated is false", () => {
+    expect(
+      resolveServerStateDir({ repoDir: "/anywhere", isolated: false, env: { XDG_STATE_HOME: "/state" } }),
+    ).toBe(path.join("/state", "codemux-server"));
+  });
+
+  it("returns the per-repo isolated dir when isolated is true", () => {
+    expect(
+      resolveServerStateDir({ repoDir: "/home/dev/codemux", isolated: true, env: { XDG_STATE_HOME: "/state" } }),
+    ).toBe(path.join("/home/dev/codemux", ".codemux-dev", "server"));
+  });
+
+  it("ignores XDG_STATE_HOME when isolated is true — the dir lives in the repo", () => {
+    const a = resolveServerStateDir({ repoDir: "/repo", isolated: true, env: { XDG_STATE_HOME: "/x" } });
+    const b = resolveServerStateDir({ repoDir: "/repo", isolated: true, env: { XDG_STATE_HOME: "/y" } });
+    expect(a).toBe(b);
+  });
+
+  it("yields a different dir per worktree in isolated mode", () => {
+    const a = resolveServerStateDir({ repoDir: "/home/alice/codemux", isolated: true });
+    const b = resolveServerStateDir({ repoDir: "/home/bob/codemux", isolated: true });
+    expect(a).not.toBe(b);
+  });
+
+  it("yields the same dir from any worktree in non-isolated mode (single-instance semantics)", () => {
+    const env = { HOME: "/home/test" };
+    const a = resolveServerStateDir({ repoDir: "/home/alice/codemux", isolated: false, env });
+    const b = resolveServerStateDir({ repoDir: "/home/bob/elsewhere", isolated: false, env });
+    expect(a).toBe(b);
+  });
+});
+
+describe("readIsolatedFromArgsAndEnv", () => {
+  it("returns true when --isolated is present", () => {
+    expect(readIsolatedFromArgsAndEnv(["--isolated"], {})).toBe(true);
+  });
+
+  it("returns false when --global is present, even if env says isolated", () => {
+    expect(readIsolatedFromArgsAndEnv(["--global"], { CODEMUX_DEV_ISOLATED: "1" })).toBe(false);
+  });
+
+  it("--isolated wins over --global when both are present", () => {
+    expect(readIsolatedFromArgsAndEnv(["--isolated", "--global"], {})).toBe(true);
+  });
+
+  it("falls back to CODEMUX_DEV_ISOLATED=1 when no flag is given", () => {
+    expect(readIsolatedFromArgsAndEnv([], { CODEMUX_DEV_ISOLATED: "1" })).toBe(true);
+  });
+
+  it("returns false when neither flag nor env is set", () => {
+    expect(readIsolatedFromArgsAndEnv([], {})).toBe(false);
+  });
+
+  it("treats CODEMUX_DEV_ISOLATED=0 as non-isolated", () => {
+    expect(readIsolatedFromArgsAndEnv([], { CODEMUX_DEV_ISOLATED: "0" })).toBe(false);
+  });
+
+  it("treats any non-`1` value as non-isolated (strict match)", () => {
+    expect(readIsolatedFromArgsAndEnv([], { CODEMUX_DEV_ISOLATED: "true" })).toBe(false);
+    expect(readIsolatedFromArgsAndEnv([], { CODEMUX_DEV_ISOLATED: "yes" })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Why

Two long-running goals were colliding:

1. **Single-instance headless server** — `bun run server:up` should give you one long-lived headless server that survives branch switches. Stopping or checking its status from any worktree should work. The pid/log/url files were already in a machine-global path (`~/.local/state/codemux-server/`), and that was correct.
2. **Multi-worktree concurrent development** — `bun run dev:isolated` already solves this for the Electron desktop loop (port offset + lockfile + `<repo>/.codemux-dev/` for userData / sessionData / logs / ports.json). Server mode had no equivalent, so people resorted to manual port-juggling.

The previous PR shape (per-folder STATE_DIR slugged by `<basename>-<sha1[:12]>`) quietly broke goal #1 to inch toward goal #2 — `server:status` from worktree B no longer saw the server you'd started in worktree A. That's a regression for the most common workflow, so this PR has been re-scoped.

## What

Keep the two semantics cleanly separate, with the new isolated path reusing all of `dev:isolated`'s machinery rather than reinventing it.

| Command | STATE_DIR | userData / settings | ports |
|---|---|---|---|
| `server:up` / `server:dev` / `server:tunnel` (default, unchanged) | `~/.local/state/codemux-server/` (global) | `~/.config/codemux/` (shared) | 8233 / 4200 / … (default) |
| `server:dev:isolated` (new) | `<repo>/.codemux-dev/server/` | `<repo>/.codemux-dev/userData/` | default + auto-allocated offset |

`server:dev:isolated` is just `dev-isolated.ts` with a `--server` flag — it reuses the existing port allocator, port lockfile, and `CODEMUX_DEV_ISOLATED` userData redirection, just spawning `bash scripts/server-dev.sh start --foreground` instead of `bun run dev`. No duplicate isolation system.

### Files

- **`scripts/state-dir.ts`** (new): single source of truth. `resolveServerStateDir({ repoDir, isolated })` + CLI entry point so bash and TypeScript agree on path resolution.
- **`scripts/server-dev.sh`**: shells out to `state-dir.ts` once; honours `CODEMUX_DEV_ISOLATED` transparently via env passthrough.
- **`scripts/tunnel-manager.ts`**: same helper for the fallback path when `CODEMUX_SERVER_STATE_DIR` is unset; logs the resolved dir + source once on first access.
- **`scripts/dev-isolated.ts`**: `--server` flag via the unit-testable `resolveSpawnTarget()` helper.
- **`package.json`**: adds `"server:dev:isolated"`.
- **Tests**: 23 new for `state-dir.ts`, 4 new for `resolveSpawnTarget`.

## Validation

- `bash -n scripts/server-dev.sh` ✓
- `bun scripts/state-dir.ts` → global path ✓
- `CODEMUX_DEV_ISOLATED=1 bun scripts/state-dir.ts` → `<repo>/.codemux-dev/server` ✓
- `bun scripts/state-dir.ts /x --isolated` → `/x/.codemux-dev/server` ✓
- `CODEMUX_DEV_ISOLATED=1 … --global` → global path (flag wins) ✓
- `bash scripts/server-dev.sh status` from any worktree sees the same single-instance server ✓
- `bun run typecheck` ✓
- `bun run test:unit` ✓ (88 files, 3283 tests)
