### PR TITLE
feat: feishu image attachment support + persist images so they survive reload

### DIFF
--- a/electron/main/channels/base-session-mapper.ts
+++ b/electron/main/channels/base-session-mapper.ts
@@ -49,14 +49,14 @@ export interface BaseP2PChatState {
 }
 
 /** Temporary session bound to P2P chat */
-export interface BaseTempSession {
+export interface BaseTempSession<TQueueItem = unknown> {
   conversationId: string;
   engineType: EngineType;
   directory: string;
   projectId: string;
   lastActiveAt: number;
   streamingSession?: StreamingSession;
-  messageQueue: string[];
+  messageQueue: TQueueItem[];
   processing: boolean;
 }
 
@@ -103,6 +103,7 @@ export interface PersistedBinding {
 export class BaseSessionMapper<
   B extends BaseGroupBinding = BaseGroupBinding,
   P extends BaseP2PChatState = BaseP2PChatState,
+  T extends BaseTempSession = BaseTempSession,
 > {
   // --- Group Bindings ---
   protected groupBindings = new Map<string, B>();
@@ -359,7 +360,7 @@ export class BaseSessionMapper<
   // Temp Sessions
   // =========================================================================
 
-  setTempSession(chatId: string, tempSession: BaseTempSession): void {
+  setTempSession(chatId: string, tempSession: T): void {
     const state = this.p2pChats.get(chatId);
     if (state) {
       if (state.tempSession) {
@@ -370,8 +371,8 @@ export class BaseSessionMapper<
     }
   }
 
-  getTempSession(chatId: string): BaseTempSession | undefined {
-    return this.p2pChats.get(chatId)?.tempSession;
+  getTempSession(chatId: string): T | undefined {
+    return this.p2pChats.get(chatId)?.tempSession as T | undefined;
   }
 
   clearTempSession(chatId: string): void {

--- a/electron/main/channels/dingtalk/dingtalk-adapter.ts
+++ b/electron/main/channels/dingtalk/dingtalk-adapter.ts
@@ -27,7 +27,7 @@ import { GatewayWsClient } from "../gateway-ws-client";
 import { StreamingController } from "../streaming/streaming-controller";
 import { TokenManager } from "../streaming/token-manager";
 import { TokenBucket } from "../streaming/rate-limiter";
-import { BaseSessionMapper, type PersistedBinding } from "../base-session-mapper";
+import { BaseSessionMapper, type BaseP2PChatState, type PersistedBinding } from "../base-session-mapper";
 import { createStreamingSession, type StreamingSession } from "../streaming/streaming-types";
 import { didConfigValuesChange, mergeDefinedConfig } from "../config-utils";
 import { DingTalkTransport } from "./dingtalk-transport";
@@ -49,26 +49,36 @@ import {
 import {
   DEFAULT_DINGTALK_CONFIG,
   TEMP_SESSION_TTL_MS,
+  MAX_DINGTALK_IMAGE_BYTES,
+  MAX_DINGTALK_IMAGES_PER_MESSAGE,
+  MAX_DINGTALK_TOTAL_IMAGE_BYTES,
   type DingTalkConfig,
   type DingTalkGroupBinding,
   type DingTalkTempSession,
   type DingTalkPendingSelection,
   type DingTalkMessageEvent,
+  type QueuedDingTalkMessage,
 } from "./dingtalk-types";
 import type {
   EngineType,
+  MessagePromptContent,
   UnifiedPart,
   UnifiedMessage,
   UnifiedPermission,
   UnifiedQuestion,
 } from "../../../../src/types/unified";
 import { dingtalkLog } from "../../services/logger";
+import { detectImageMime } from "../shared/image-detector";
 
 // ============================================================================
 // DingTalk Session Mapper (extends BaseSessionMapper with ownerUserId)
 // ============================================================================
 
-class DingTalkSessionMapper extends BaseSessionMapper<DingTalkGroupBinding> {
+class DingTalkSessionMapper extends BaseSessionMapper<
+  DingTalkGroupBinding,
+  BaseP2PChatState,
+  DingTalkTempSession
+> {
   constructor() {
     super("dingtalk");
   }
@@ -334,9 +344,9 @@ export class DingTalkAdapter extends ChannelAdapter {
   async handleDingTalkMessage(event: DingTalkMessageEvent): Promise<void> {
     const { msgId, conversationType, text, senderStaffId, chatId, senderNick } = event;
 
-    // Skip non-text messages
-    if (event.msgtype !== "text") {
-      dingtalkLog.verbose(`Ignoring non-text message type: ${event.msgtype}`);
+    // Accept text and picture; everything else (file/audio/...) is dropped.
+    if (event.msgtype !== "text" && event.msgtype !== "picture") {
+      dingtalkLog.verbose(`Ignoring non-text/picture message type: ${event.msgtype}`);
       return;
     }
 
@@ -346,27 +356,88 @@ export class DingTalkAdapter extends ChannelAdapter {
       return;
     }
 
-    // Extract text content and strip @mentions
-    let content = (text?.content || "").trim();
-    if (!content) return;
+    // Extract text content (picture messages may carry an empty text field).
+    const textContent = (text?.content || "").trim();
+    const hasImage = event.msgtype === "picture" && Boolean(event.picture?.downloadCode);
+    if (!textContent && !hasImage) return;
 
     const senderId = senderStaffId || event.chatbotUserId;
 
     dingtalkLog.info(
       `Message from ${conversationType === "1" ? "P2P" : "group"} ` +
-      `(${senderNick}): ${content.slice(0, 100)}`,
+      `(${senderNick}): ${textContent.slice(0, 100)}${hasImage ? " [+image]" : ""}`,
     );
+
+    // Build engine content once at the entry point (single image per DingTalk
+    // event — DingTalk does not deliver multi-image messages). Download
+    // failures are logged but do not block plain-text delivery.
+    const replyChatId =
+      conversationType === "1" ? event.conversationId : (chatId ?? event.conversationId);
+    const content = await this.buildEngineContent(replyChatId, textContent, event);
+
+    if (content.length === 0) {
+      // Nothing to send — image download failed and there was no text.
+      return;
+    }
 
     if (conversationType === "1") {
       // Individual (P2P) message
-      // For P2P, use the DingTalk conversationId as the chat identifier
       const p2pChatId = event.conversationId;
       this.sessionMapper.getOrCreateP2PChat(p2pChatId, senderId);
-      await this.handleP2PMessage(p2pChatId, senderId, content);
+      await this.handleP2PMessage(p2pChatId, senderId, textContent, content);
     } else if (conversationType === "2" && chatId) {
       // Group message — chatId is the openConversationId
-      await this.handleGroupMessage(chatId, content);
+      await this.handleGroupMessage(chatId, textContent, content);
     }
+  }
+
+  /**
+   * Build a MessagePromptContent[] payload from a DingTalk event. Downloads
+   * the picture (when present) and applies size/MIME/total-bytes limits.
+   * Plain-text messages take the fast path with no async work.
+   */
+  private async buildEngineContent(
+    replyChatId: string,
+    text: string,
+    event: DingTalkMessageEvent,
+  ): Promise<MessagePromptContent[]> {
+    const out: MessagePromptContent[] = [];
+    if (text) out.push({ type: "text", text });
+
+    if (event.msgtype !== "picture" || !event.picture?.downloadCode) {
+      return out;
+    }
+    if (!this.transport) return out;
+
+    try {
+      const buf = await this.transport.downloadByCode(event.picture.downloadCode);
+      if (buf.length > MAX_DINGTALK_IMAGE_BYTES) {
+        await this.transport.sendText(
+          replyChatId,
+          `⚠️ 图片超过 ${Math.floor(MAX_DINGTALK_IMAGE_BYTES / (1024 * 1024))}MB 已忽略`,
+        );
+        return out;
+      }
+      if (buf.length > MAX_DINGTALK_TOTAL_IMAGE_BYTES) {
+        // Defensive — single-image case mirrors per-image cap; included for symmetry.
+        await this.transport.sendText(replyChatId, "⚠️ 图片总大小超过限制");
+        return out;
+      }
+      // MAX_DINGTALK_IMAGES_PER_MESSAGE is informational here since DingTalk
+      // events carry one image; included to keep the cap surface consistent.
+      void MAX_DINGTALK_IMAGES_PER_MESSAGE;
+
+      const mimeType = detectImageMime(buf);
+      if (!mimeType) {
+        await this.transport.sendText(replyChatId, "⚠️ 不支持的图片格式");
+        return out;
+      }
+      out.push({ type: "image", data: buf.toString("base64"), mimeType });
+    } catch (err) {
+      dingtalkLog.error("Failed to download DingTalk image:", err);
+      await this.transport.sendText(replyChatId, "⚠️ 图片下载失败");
+    }
+    return out;
   }
 
   // ============================================================================
@@ -406,7 +477,12 @@ export class DingTalkAdapter extends ChannelAdapter {
   // P2P Message Handling (Entry Point Only)
   // ============================================================================
 
-  private async handleP2PMessage(chatId: string, senderId: string, text: string): Promise<void> {
+  private async handleP2PMessage(
+    chatId: string,
+    senderId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     // 1. Check for slash commands first
     const command = parseCommand(text);
     if (command) {
@@ -437,7 +513,7 @@ export class DingTalkAdapter extends ChannelAdapter {
     // 4. Active temp session (not expired)? → send to engine
     const tempSession = this.sessionMapper.getTempSession(chatId);
     if (tempSession && !this.isTempSessionExpired(tempSession)) {
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content);
       return;
     }
 
@@ -447,7 +523,7 @@ export class DingTalkAdapter extends ChannelAdapter {
       if (tempSession) {
         await this.cleanupExpiredTempSession(chatId);
       }
-      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text);
+      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text, undefined, content);
       return;
     }
 
@@ -464,7 +540,7 @@ export class DingTalkAdapter extends ChannelAdapter {
           engineType: defaultProject.engineType,
           projectId: defaultProject.id,
         };
-        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区", content);
         return;
       }
     }
@@ -666,6 +742,7 @@ export class DingTalkAdapter extends ChannelAdapter {
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
     projectName?: string,
+    content?: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -688,7 +765,7 @@ export class DingTalkAdapter extends ChannelAdapter {
       this.sessionMapper.setTempSession(chatId, tempSession);
       const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
       await this.transport!.sendMarkdown(chatId, buildSessionNotification(name, session.engineType, session.id));
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content ?? [{ type: "text", text }]);
     } catch (err) {
       await this.transport!.sendMarkdown(
         chatId,
@@ -698,11 +775,15 @@ export class DingTalkAdapter extends ChannelAdapter {
   }
 
   /** Enqueue a message for serial processing in the P2P temp session */
-  private async enqueueP2PMessage(chatId: string, text: string): Promise<void> {
+  private async enqueueP2PMessage(
+    chatId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     const temp = this.sessionMapper.getTempSession(chatId);
     if (!temp) return;
 
-    temp.messageQueue.push(text);
+    temp.messageQueue.push({ text, content });
     if (!temp.processing) {
       await this.processP2PQueue(chatId);
     }
@@ -717,15 +798,15 @@ export class DingTalkAdapter extends ChannelAdapter {
     }
 
     temp.processing = true;
-    const text = temp.messageQueue.shift()!;
-    await this.sendToEngineP2P(chatId, temp, text);
+    const queued = temp.messageQueue.shift()!;
+    await this.sendToEngineP2P(chatId, temp, queued);
   }
 
   /** Send a message to the engine via a P2P temp session */
   private async sendToEngineP2P(
     chatId: string,
     tempSession: DingTalkTempSession,
-    text: string,
+    queued: QueuedDingTalkMessage,
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) {
       tempSession.processing = false;
@@ -742,7 +823,7 @@ export class DingTalkAdapter extends ChannelAdapter {
 
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: tempSession.conversationId,
-      content: [{ type: "text", text }],
+      content: queued.content,
     });
 
     sendPromise
@@ -880,7 +961,11 @@ export class DingTalkAdapter extends ChannelAdapter {
   // Group Message Handling (Session Interaction)
   // ============================================================================
 
-  private async handleGroupMessage(groupChatId: string, text: string): Promise<void> {
+  private async handleGroupMessage(
+    groupChatId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     const binding = this.sessionMapper.getGroupBinding(groupChatId);
     if (!binding) {
       await this.transport!.sendMarkdown(groupChatId, "📋 此群聊未绑定到 CodeMux 会话。");
@@ -906,7 +991,7 @@ export class DingTalkAdapter extends ChannelAdapter {
     }
 
     // Regular message → send to engine
-    await this.sendToEngine(groupChatId, binding, text);
+    await this.sendToEngine(groupChatId, binding, content);
   }
 
   private async handleGroupCommand(
@@ -1068,7 +1153,7 @@ export class DingTalkAdapter extends ChannelAdapter {
   private async sendToEngine(
     groupChatId: string,
     binding: DingTalkGroupBinding,
-    text: string,
+    content: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) return;
 
@@ -1081,7 +1166,7 @@ export class DingTalkAdapter extends ChannelAdapter {
     // Send message to engine via Gateway (non-blocking)
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: binding.conversationId,
-      content: [{ type: "text", text }],
+      content,
     });
 
     sendPromise

--- a/electron/main/channels/dingtalk/dingtalk-transport.ts
+++ b/electron/main/channels/dingtalk/dingtalk-transport.ts
@@ -403,4 +403,39 @@ export class DingTalkTransport implements MessageTransport {
         return "sampleText";
     }
   }
+
+  // =========================================================================
+  // Image / File Download
+  // =========================================================================
+
+  /**
+   * Resolve a DingTalk `downloadCode` (from picture/file events) to a byte
+   * buffer. The `robot/messageFiles/download` endpoint returns a short-lived
+   * presigned URL which we immediately fetch.
+   */
+  async downloadByCode(downloadCode: string): Promise<Buffer> {
+    const token = await this.tokenManager.getToken();
+    const res = await fetch(`${API_BASE}/robot/messageFiles/download`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-acs-dingtalk-access-token": token,
+      },
+      body: JSON.stringify({
+        downloadCode,
+        robotCode: this.robotCode,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`messageFiles/download status ${res.status}: ${await res.text()}`);
+    }
+    const data = (await res.json()) as { downloadUrl?: string };
+    if (!data.downloadUrl) throw new Error("messageFiles/download: missing downloadUrl");
+    const fileRes = await fetch(data.downloadUrl);
+    if (!fileRes.ok) {
+      throw new Error(`download status ${fileRes.status}`);
+    }
+    const ab = await fileRes.arrayBuffer();
+    return Buffer.from(ab);
+  }
 }

--- a/electron/main/channels/dingtalk/dingtalk-types.ts
+++ b/electron/main/channels/dingtalk/dingtalk-types.ts
@@ -4,7 +4,7 @@
 // Architecture: One Group Chat = One CodeMux Session (same as Feishu adapter)
 // ============================================================================
 
-import type { EngineType, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
+import type { EngineType, MessagePromptContent, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
 import type { BaseGroupBinding } from "../base-session-mapper";
 
 // Re-export shared streaming types for convenience
@@ -43,6 +43,26 @@ export const DEFAULT_DINGTALK_CONFIG: DingTalkConfig = {
 
 /** TTL for temporary P2P sessions (2 hours in ms) */
 export const TEMP_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+
+// Image limits are sourced from the shared module so frontend, channels, and
+// the gateway-side persistence path stay in sync.
+export {
+  MAX_IMAGE_SIZE_BYTES as MAX_DINGTALK_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE as MAX_DINGTALK_IMAGES_PER_MESSAGE,
+  MAX_TOTAL_IMAGE_BYTES as MAX_DINGTALK_TOTAL_IMAGE_BYTES,
+} from "../../../../shared/image-limits";
+
+/**
+ * A queued DingTalk message awaiting engine dispatch. Carries already-built
+ * MessagePromptContent so the queue worker can call sendMessage directly
+ * without re-downloading images.
+ */
+export interface QueuedDingTalkMessage {
+  /** Plain-text preview (for logging only). */
+  text: string;
+  /** Engine-ready prompt content (text + images). */
+  content: MessagePromptContent[];
+}
 
 // --- Group Binding (One Group = One Session) ---
 
@@ -88,7 +108,7 @@ export interface DingTalkTempSession {
   /** Current streaming session (if any) */
   streamingSession?: import("../streaming/streaming-types").StreamingSession;
   /** Message queue for serial processing */
-  messageQueue: string[];
+  messageQueue: QueuedDingTalkMessage[];
   /** Whether currently processing a message */
   processing: boolean;
 }
@@ -141,8 +161,13 @@ export interface DingTalkMessageEvent {
   isInAtList?: boolean;
   /** Text content of the message */
   text: { content: string };
-  /** Message type (e.g., "text") */
+  /** Message type (e.g., "text", "picture") */
   msgtype: string;
+  /**
+   * Picture payload (present when msgtype="picture"). The `downloadCode` is
+   * exchanged for a presigned URL via the `robot/messageFiles/download` API.
+   */
+  picture?: { downloadCode: string };
 }
 
 // --- Command Parser Types ---

--- a/electron/main/channels/feishu/feishu-adapter.ts
+++ b/electron/main/channels/feishu/feishu-adapter.ts
@@ -40,8 +40,11 @@ import {
 import {
   DEFAULT_FEISHU_CONFIG,
   TEMP_SESSION_TTL_MS,
+  MAX_FEISHU_IMAGE_BYTES,
+  MAX_FEISHU_IMAGES_PER_MESSAGE,
   type FeishuConfig,
   type GroupBinding,
+  type QueuedFeishuMessage,
   type TempSession,
   type FeishuMessageEvent,
   type FeishuBotMenuEvent,
@@ -54,8 +57,15 @@ import {
   getLarkDomain,
   normalizeFeishuPlatform,
 } from "./feishu-platform";
+import {
+  buildPromptContent,
+  detectImageMime,
+  parseFeishuMessageContent,
+  type ParsedContentPart,
+} from "./feishu-content-parser";
 import type {
   EngineType,
+  MessagePromptContent,
   UnifiedPart,
   UnifiedMessage,
   UnifiedPermission,
@@ -571,13 +581,16 @@ export class FeishuAdapter extends ChannelAdapter {
   // Feishu Message Handling (P2P vs Group routing)
   // ============================================================================
 
+  // Message types from `im.message.receive_v1` that may carry user-visible content.
+  // Text / image / post (rich text) are the cases we route to the engine.
+  private static readonly SUPPORTED_MESSAGE_TYPES = new Set(["text", "image", "post"]);
+
   private async handleFeishuMessage(event: FeishuMessageEvent): Promise<void> {
     const { message, sender } = event;
     const { chat_id, chat_type, content, message_id, message_type } = message;
 
-    // Skip non-text messages
-    if (message_type !== "text") {
-      this.channelLog.verbose(`Ignoring non-text message type: ${message_type}`);
+    if (!FeishuAdapter.SUPPORTED_MESSAGE_TYPES.has(message_type)) {
+      this.channelLog.verbose(`Ignoring unsupported message type: ${message_type}`);
       return;
     }
 
@@ -587,20 +600,17 @@ export class FeishuAdapter extends ChannelAdapter {
       return;
     }
 
-    // Parse content JSON
-    let text: string;
-    try {
-      const parsed = JSON.parse(content);
-      text = parsed.text || "";
-    } catch {
-      text = content;
-    }
+    // Parse into ordered parts (text + image-key references). No network yet.
+    const parsed = parseFeishuMessageContent(message_type, content);
+    if (!parsed.text && parsed.parts.length === 0) return;
 
-    // Strip @mentions from text (Feishu includes @_user_1 style placeholders)
-    text = text.replace(/@_user_\d+/g, "").trim();
-    if (!text) return;
-
-    this.channelLog.info(`Message from ${chat_type} chat ${chat_id}: ${text.slice(0, 100)}`);
+    const imageCount = parsed.parts.reduce(
+      (n, p) => n + (p.type === "image-key" ? 1 : 0),
+      0,
+    );
+    this.channelLog.info(
+      `Message from ${chat_type} chat ${chat_id} (type=${message_type}, images=${imageCount}): ${parsed.text.slice(0, 100)}`,
+    );
 
     if (chat_type === "p2p") {
       // Record open_id → chat_id mapping for bot menu events
@@ -615,29 +625,108 @@ export class FeishuAdapter extends ChannelAdapter {
           this.channelLog.info(`Transferred pending selection from openId=${sender.sender_id.open_id} to chat=${chat_id}`);
         }
       }
-      await this.handleP2PMessage(chat_id, text);
+      await this.handleP2PMessage(chat_id, parsed.text, message_id, parsed.parts);
     } else if (chat_type === "group") {
       // No @mention requirement — bot-owned group, all messages are for bot
-      await this.handleGroupMessage(chat_id, text);
+      await this.handleGroupMessage(chat_id, parsed.text, message_id, parsed.parts);
     }
+  }
+
+  // ============================================================================
+  // Image Download Helpers (Engine-bound content building)
+  // ============================================================================
+
+  /**
+   * Download all image attachments referenced by `parts` and return a map from
+   * image_key to base64 data + detected MIME type. Caps the number of images
+   * at MAX_FEISHU_IMAGES_PER_MESSAGE and each download at MAX_FEISHU_IMAGE_BYTES.
+   * Images that fail to download, exceed the size limit, or have unknown
+   * formats are skipped (with a log entry).
+   */
+  private async downloadImagesForParts(
+    messageId: string,
+    parts: ParsedContentPart[],
+  ): Promise<Map<string, { data: string; mimeType: string }>> {
+    const map = new Map<string, { data: string; mimeType: string }>();
+    if (!this.transport) return map;
+
+    const seen = new Set<string>();
+    for (const p of parts) {
+      if (p.type !== "image-key") continue;
+      if (seen.has(p.imageKey)) continue;
+      seen.add(p.imageKey);
+
+      if (map.size >= MAX_FEISHU_IMAGES_PER_MESSAGE) {
+        this.channelLog.warn(
+          `Dropping image ${p.imageKey} for message ${messageId} (max ${MAX_FEISHU_IMAGES_PER_MESSAGE} per message)`,
+        );
+        continue;
+      }
+
+      const buf = await this.transport.downloadMessageImage(
+        messageId,
+        p.imageKey,
+        MAX_FEISHU_IMAGE_BYTES,
+      );
+      if (!buf) continue;
+
+      const mimeType = detectImageMime(buf);
+      if (!mimeType) {
+        this.channelLog.warn(
+          `Dropping image ${p.imageKey} for message ${messageId} (unrecognized format)`,
+        );
+        continue;
+      }
+
+      map.set(p.imageKey, { data: buf.toString("base64"), mimeType });
+    }
+    return map;
+  }
+
+  /**
+   * Build a MessagePromptContent[] payload for the engine. Downloads any
+   * referenced images. If no images are referenced, takes a fast text-only path.
+   * Falls back to text-only if every image download fails but text is present.
+   */
+  private async buildEngineContent(
+    messageId: string,
+    text: string,
+    parts: ParsedContentPart[],
+  ): Promise<MessagePromptContent[]> {
+    const hasImageKeys = parts.some(p => p.type === "image-key");
+    if (!hasImageKeys) {
+      return text ? [{ type: "text", text }] : [];
+    }
+
+    const images = await this.downloadImagesForParts(messageId, parts);
+    const content = buildPromptContent(parts, images);
+    if (content.length === 0 && text) {
+      return [{ type: "text", text }];
+    }
+    return content;
   }
 
   // ============================================================================
   // P2P Message Handling (Entry Point Only)
   // ============================================================================
 
-  private async handleP2PMessage(chatId: string, text: string): Promise<void> {
-    // 1. Check for slash commands first
-    const command = parseCommand(text);
+  private async handleP2PMessage(
+    chatId: string,
+    text: string,
+    messageId: string,
+    parts: ParsedContentPart[],
+  ): Promise<void> {
+    // 1. Slash commands — require text
+    const command = text ? parseCommand(text) : null;
     if (command) {
       this.sessionMapper.clearPendingSelection(chatId);
       await this.handleP2PCommand(chatId, command);
       return;
     }
 
-    // 2. Check for pending question — treat any reply as a freeform answer
+    // 2. Pending question — reply with text only (image-only falls through to engine)
     const pendingQ = this.sessionMapper.getPendingQuestion(chatId);
-    if (pendingQ && this.gatewayClient) {
+    if (pendingQ && text && this.gatewayClient) {
       this.sessionMapper.clearPendingQuestion(chatId);
       await this.gatewayClient.replyQuestion({
         questionId: pendingQ.questionId,
@@ -647,17 +736,23 @@ export class FeishuAdapter extends ChannelAdapter {
       return;
     }
 
-    // 3. Check for pending selection (number reply or "new")
+    // 3. Pending selection (number reply) — text only
     const pending = this.sessionMapper.getPendingSelection(chatId);
-    if (pending) {
+    if (pending && text) {
       const handled = await this.handlePendingSelection(chatId, text, pending);
       if (handled) return;
     }
 
+    // Build engine-bound content (downloads any images now). If nothing remains
+    // (e.g. all images failed and no text), drop the message.
+    const content = await this.buildEngineContent(messageId, text, parts);
+    if (content.length === 0) return;
+    const queued: QueuedFeishuMessage = { text, content };
+
     // 4. Active temp session (not expired)? → send to engine
     const tempSession = this.sessionMapper.getTempSession(chatId);
     if (tempSession && !this.isTempSessionExpired(tempSession)) {
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, queued);
       return;
     }
 
@@ -668,7 +763,7 @@ export class FeishuAdapter extends ChannelAdapter {
       if (tempSession) {
         await this.cleanupExpiredTempSession(chatId);
       }
-      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text);
+      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, queued);
       return;
     }
 
@@ -686,7 +781,7 @@ export class FeishuAdapter extends ChannelAdapter {
           engineType: defaultProject.engineType,
           projectId: defaultProject.id,
         };
-        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        await this.createTempSessionAndSend(chatId, defaultRef, queued, "默认工作区");
         return;
       }
     }
@@ -920,7 +1015,7 @@ export class FeishuAdapter extends ChannelAdapter {
   private async createTempSessionAndSend(
     chatId: string,
     project: { directory: string; engineType?: EngineType; projectId: string },
-    text: string,
+    queued: QueuedFeishuMessage,
     projectName?: string,
   ): Promise<void> {
     if (!this.gatewayClient) return;
@@ -944,7 +1039,7 @@ export class FeishuAdapter extends ChannelAdapter {
       this.sessionMapper.setTempSession(chatId, tempSession);
       const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
       await this.transport!.sendMarkdown(chatId, buildSessionNotification(name, session.engineType, session.id));
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, queued);
     } catch (err) {
       await this.transport!.sendMarkdown(
         chatId,
@@ -954,11 +1049,11 @@ export class FeishuAdapter extends ChannelAdapter {
   }
 
   /** Enqueue a message for serial processing in the P2P temp session */
-  private async enqueueP2PMessage(chatId: string, text: string): Promise<void> {
+  private async enqueueP2PMessage(chatId: string, queued: QueuedFeishuMessage): Promise<void> {
     const temp = this.sessionMapper.getTempSession(chatId);
     if (!temp) return;
 
-    temp.messageQueue.push(text);
+    temp.messageQueue.push(queued);
     if (!temp.processing) {
       await this.processP2PQueue(chatId);
     }
@@ -973,15 +1068,15 @@ export class FeishuAdapter extends ChannelAdapter {
     }
 
     temp.processing = true;
-    const text = temp.messageQueue.shift()!;
-    await this.sendToEngineP2P(chatId, temp, text);
+    const queued = temp.messageQueue.shift()!;
+    await this.sendToEngineP2P(chatId, temp, queued);
   }
 
   /** Send a message to the engine via a P2P temp session (no group) */
   private async sendToEngineP2P(
     chatId: string,
     tempSession: TempSession,
-    text: string,
+    queued: QueuedFeishuMessage,
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) {
       tempSession.processing = false;
@@ -1008,7 +1103,7 @@ export class FeishuAdapter extends ChannelAdapter {
 
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: tempSession.conversationId,
-      content: [{ type: "text", text }],
+      content: queued.content,
     });
 
     sendPromise
@@ -1158,22 +1253,27 @@ export class FeishuAdapter extends ChannelAdapter {
   // Group Message Handling (Session Interaction)
   // ============================================================================
 
-  private async handleGroupMessage(groupChatId: string, text: string): Promise<void> {
+  private async handleGroupMessage(
+    groupChatId: string,
+    text: string,
+    messageId: string,
+    parts: ParsedContentPart[],
+  ): Promise<void> {
     const binding = this.sessionMapper.getGroupBinding(groupChatId);
     if (!binding) {
       await this.transport!.sendMarkdown(groupChatId, "📋 此群聊未绑定到 CodeMux 会话。");
       return;
     }
 
-    const command = parseCommand(text);
+    const command = text ? parseCommand(text) : null;
     if (command) {
       await this.handleGroupCommand(groupChatId, binding, command);
       return;
     }
 
-    // Check for pending question — treat any reply as a freeform answer
+    // Pending question — reply with text only (image-only falls through to engine)
     const pendingQ = this.sessionMapper.getPendingQuestion(groupChatId);
-    if (pendingQ && this.gatewayClient) {
+    if (pendingQ && text && this.gatewayClient) {
       this.sessionMapper.clearPendingQuestion(groupChatId);
       await this.gatewayClient.replyQuestion({
         questionId: pendingQ.questionId,
@@ -1183,8 +1283,10 @@ export class FeishuAdapter extends ChannelAdapter {
       return;
     }
 
-    // Regular message → send to engine
-    await this.sendToEngine(groupChatId, binding, text);
+    const content = await this.buildEngineContent(messageId, text, parts);
+    if (content.length === 0) return;
+
+    await this.sendToEngine(groupChatId, binding, { text, content });
   }
 
   private async handleGroupCommand(
@@ -1460,7 +1562,7 @@ export class FeishuAdapter extends ChannelAdapter {
   private async sendToEngine(
     groupChatId: string,
     binding: GroupBinding,
-    text: string,
+    queued: QueuedFeishuMessage,
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) return;
 
@@ -1484,7 +1586,7 @@ export class FeishuAdapter extends ChannelAdapter {
     // Send message to engine via Gateway (non-blocking)
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: binding.conversationId,
-      content: [{ type: "text", text }],
+      content: queued.content,
     });
 
     sendPromise

--- a/electron/main/channels/feishu/feishu-adapter.ts
+++ b/electron/main/channels/feishu/feishu-adapter.ts
@@ -746,17 +746,37 @@ export class FeishuAdapter extends ChannelAdapter {
       return;
     }
 
-    // 3. Pending selection (number reply) — text only
+    // 3. Pending selection (number reply) — text only.
+    //
+    // The pending state can only be consumed by a *text* reply (the user typing
+    // a number). An image-only message means the user has moved past the
+    // selection prompt without answering it, so clear the stale state to avoid
+    // misinterpreting a later unrelated numeric message as the deferred answer.
     const pending = this.sessionMapper.getPendingSelection(chatId);
-    if (pending && text) {
-      const handled = await this.handlePendingSelection(chatId, text, pending);
-      if (handled) return;
+    if (pending) {
+      if (text) {
+        const handled = await this.handlePendingSelection(chatId, text, pending);
+        if (handled) return;
+      } else {
+        this.sessionMapper.clearPendingSelection(chatId);
+      }
     }
 
     // Build engine-bound content (downloads any images now). If nothing remains
-    // (e.g. all images failed and no text), drop the message.
+    // (e.g. all images failed and no text), notify the user instead of silently
+    // dropping the message — mirroring the user-visible notices the DingTalk,
+    // WeCom, Telegram, and Teams adapters emit on image-rejection paths.
     const content = await this.buildEngineContent(messageId, text, parts);
-    if (content.length === 0) return;
+    if (content.length === 0) {
+      const hadImageOnly = !text && parts.some(p => p.type === "image-key");
+      if (hadImageOnly && this.transport) {
+        await this.transport.sendText(
+          chatId,
+          "⚠️ 图片处理失败，未送达。请检查图片格式（jpeg/png/gif/webp）和大小（单张 ≤ 3 MB，总量 ≤ 12 MB）后重试。",
+        );
+      }
+      return;
+    }
     const queued: QueuedFeishuMessage = { text, content };
 
     // 4. Active temp session (not expired)? → send to engine

--- a/electron/main/channels/feishu/feishu-adapter.ts
+++ b/electron/main/channels/feishu/feishu-adapter.ts
@@ -42,6 +42,7 @@ import {
   TEMP_SESSION_TTL_MS,
   MAX_FEISHU_IMAGE_BYTES,
   MAX_FEISHU_IMAGES_PER_MESSAGE,
+  MAX_FEISHU_TOTAL_IMAGE_BYTES,
   type FeishuConfig,
   type GroupBinding,
   type QueuedFeishuMessage,
@@ -59,10 +60,10 @@ import {
 } from "./feishu-platform";
 import {
   buildPromptContent,
-  detectImageMime,
   parseFeishuMessageContent,
   type ParsedContentPart,
 } from "./feishu-content-parser";
+import { detectImageMime } from "../shared/image-detector";
 import type {
   EngineType,
   MessagePromptContent,
@@ -651,6 +652,7 @@ export class FeishuAdapter extends ChannelAdapter {
     if (!this.transport) return map;
 
     const seen = new Set<string>();
+    let totalBytes = 0;
     for (const p of parts) {
       if (p.type !== "image-key") continue;
       if (seen.has(p.imageKey)) continue;
@@ -670,6 +672,13 @@ export class FeishuAdapter extends ChannelAdapter {
       );
       if (!buf) continue;
 
+      if (totalBytes + buf.length > MAX_FEISHU_TOTAL_IMAGE_BYTES) {
+        this.channelLog.warn(
+          `Dropping image ${p.imageKey} for message ${messageId} (total > ${MAX_FEISHU_TOTAL_IMAGE_BYTES} bytes)`,
+        );
+        continue;
+      }
+
       const mimeType = detectImageMime(buf);
       if (!mimeType) {
         this.channelLog.warn(
@@ -678,6 +687,7 @@ export class FeishuAdapter extends ChannelAdapter {
         continue;
       }
 
+      totalBytes += buf.length;
       map.set(p.imageKey, { data: buf.toString("base64"), mimeType });
     }
     return map;

--- a/electron/main/channels/feishu/feishu-content-parser.ts
+++ b/electron/main/channels/feishu/feishu-content-parser.ts
@@ -1,0 +1,214 @@
+// ============================================================================
+// Feishu Message Content Parser
+// Pure parsing utilities for Feishu (Lark) message events.
+// Converts text/image/post message bodies into ordered content parts.
+// ============================================================================
+
+import type { MessagePromptContent } from "../../../../src/types/unified";
+
+/** An ordered piece of message content extracted from a Feishu message body. */
+export type ParsedContentPart =
+  | { type: "text"; text: string }
+  | { type: "image-key"; imageKey: string };
+
+/** Result of parsing a Feishu message body. */
+export interface ParsedFeishuMessage {
+  /** Plain-text representation (used for commands, dedup keys, display). */
+  text: string;
+  /** Ordered parts (text + image-key) used for engine sending. */
+  parts: ParsedContentPart[];
+}
+
+/** Strip Feishu @mention placeholders like `@_user_1` from plain text. */
+export function stripFeishuMentions(value: string): string {
+  return value.replace(/@_user_\d+/g, "");
+}
+
+/**
+ * Parse a Feishu message event body into ordered content parts and plain text.
+ *
+ * Supported message types:
+ *   - "text":  `{"text":"..."}`
+ *   - "image": `{"image_key":"img_xxx"}`
+ *   - "post":  `{"title":"...","content":[[ {tag:"text"|"a"|"at"|"code_inline"|"img", ...} ]]}`
+ *
+ * Unknown types yield `{ text: "", parts: [] }`.
+ */
+export function parseFeishuMessageContent(
+  messageType: string,
+  contentJson: string,
+): ParsedFeishuMessage {
+  if (messageType === "text") {
+    return parseTextMessage(contentJson);
+  }
+  if (messageType === "image") {
+    return parseImageMessage(contentJson);
+  }
+  if (messageType === "post") {
+    return parsePostMessage(contentJson);
+  }
+  return { text: "", parts: [] };
+}
+
+function parseTextMessage(contentJson: string): ParsedFeishuMessage {
+  let rawText = "";
+  try {
+    const parsed = JSON.parse(contentJson);
+    rawText = typeof parsed?.text === "string" ? parsed.text : "";
+  } catch {
+    rawText = contentJson;
+  }
+  const text = stripFeishuMentions(rawText).trim();
+  if (!text) return { text: "", parts: [] };
+  return { text, parts: [{ type: "text", text }] };
+}
+
+function parseImageMessage(contentJson: string): ParsedFeishuMessage {
+  let imageKey = "";
+  try {
+    const parsed = JSON.parse(contentJson);
+    imageKey = typeof parsed?.image_key === "string" ? parsed.image_key : "";
+  } catch {
+    // Ignore parsing failure — treat as no image
+  }
+  if (!imageKey) return { text: "", parts: [] };
+  return { text: "", parts: [{ type: "image-key", imageKey }] };
+}
+
+interface PostElement {
+  tag?: unknown;
+  text?: unknown;
+  href?: unknown;
+  user_name?: unknown;
+  image_key?: unknown;
+}
+
+function parsePostMessage(contentJson: string): ParsedFeishuMessage {
+  let post: { title?: unknown; content?: unknown } | null = null;
+  try {
+    post = JSON.parse(contentJson) as { title?: unknown; content?: unknown };
+  } catch {
+    return { text: "", parts: [] };
+  }
+
+  const parts: ParsedContentPart[] = [];
+  const textBuf: string[] = [];
+
+  const title = typeof post?.title === "string" ? post.title.trim() : "";
+  if (title) {
+    parts.push({ type: "text", text: title });
+    textBuf.push(title);
+  }
+
+  const rows = Array.isArray(post?.content) ? (post.content as unknown[]) : [];
+  for (const row of rows) {
+    if (!Array.isArray(row)) continue;
+    const rowText: string[] = [];
+    for (const el of row as PostElement[]) {
+      if (!el || typeof el !== "object") continue;
+      const tag = typeof el.tag === "string" ? el.tag : "";
+
+      if (tag === "text" && typeof el.text === "string") {
+        rowText.push(el.text);
+      } else if (tag === "a" && typeof el.text === "string") {
+        const href = typeof el.href === "string" ? el.href : "";
+        rowText.push(href ? `[${el.text}](${href})` : el.text);
+      } else if (tag === "at" && typeof el.user_name === "string") {
+        rowText.push(`@${el.user_name}`);
+      } else if (tag === "code_inline" && typeof el.text === "string") {
+        rowText.push(`\`${el.text}\``);
+      } else if (tag === "img" && typeof el.image_key === "string" && el.image_key) {
+        // Flush pending row text before the image so ordering is preserved.
+        if (rowText.length > 0) {
+          const joined = rowText.join("");
+          parts.push({ type: "text", text: joined });
+          textBuf.push(joined);
+          rowText.length = 0;
+        }
+        parts.push({ type: "image-key", imageKey: el.image_key });
+      }
+    }
+    if (rowText.length > 0) {
+      const joined = rowText.join("");
+      parts.push({ type: "text", text: joined });
+      textBuf.push(joined);
+    }
+  }
+
+  // Strip mentions / trim each text part for safety
+  const cleanedParts: ParsedContentPart[] = [];
+  for (const p of parts) {
+    if (p.type === "text") {
+      const cleaned = stripFeishuMentions(p.text).trim();
+      if (cleaned) cleanedParts.push({ type: "text", text: cleaned });
+    } else {
+      cleanedParts.push(p);
+    }
+  }
+
+  const text = stripFeishuMentions(textBuf.join("\n")).trim();
+  return { text, parts: cleanedParts };
+}
+
+/**
+ * Detect image MIME type from a buffer's leading bytes ("magic numbers").
+ * Returns null when the format is not recognized — callers should skip such images.
+ */
+export function detectImageMime(buf: Buffer): string | null {
+  if (buf.length >= 8 &&
+      buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+      buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a) {
+    return "image/png";
+  }
+  if (buf.length >= 3 &&
+      buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (buf.length >= 6 &&
+      buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38 &&
+      (buf[4] === 0x37 || buf[4] === 0x39) && buf[5] === 0x61) {
+    return "image/gif";
+  }
+  if (buf.length >= 12 &&
+      buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+      buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50) {
+    return "image/webp";
+  }
+  return null;
+}
+
+/**
+ * Build a MessagePromptContent[] from ordered parsed parts and a map of
+ * already-downloaded image data keyed by image key. Parts whose image key is
+ * missing from the map (e.g. download failed / size exceeded) are dropped.
+ *
+ * Consecutive text parts are joined with newlines to keep the payload small.
+ */
+export function buildPromptContent(
+  parts: ParsedContentPart[],
+  imageData: Map<string, { data: string; mimeType: string }>,
+): MessagePromptContent[] {
+  const out: MessagePromptContent[] = [];
+  let textBuf: string[] = [];
+
+  const flushText = () => {
+    if (textBuf.length === 0) return;
+    const joined = textBuf.join("\n").trim();
+    if (joined) out.push({ type: "text", text: joined });
+    textBuf = [];
+  };
+
+  for (const p of parts) {
+    if (p.type === "text") {
+      if (p.text.trim()) textBuf.push(p.text);
+      continue;
+    }
+    const img = imageData.get(p.imageKey);
+    if (!img) continue;
+    flushText();
+    out.push({ type: "image", data: img.data, mimeType: img.mimeType });
+  }
+  flushText();
+
+  return out;
+}

--- a/electron/main/channels/feishu/feishu-content-parser.ts
+++ b/electron/main/channels/feishu/feishu-content-parser.ts
@@ -51,7 +51,7 @@ export function parseFeishuMessageContent(
 }
 
 function parseTextMessage(contentJson: string): ParsedFeishuMessage {
-  let rawText = "";
+  let rawText: string;
   try {
     const parsed = JSON.parse(contentJson);
     rawText = typeof parsed?.text === "string" ? parsed.text : "";
@@ -84,7 +84,7 @@ interface PostElement {
 }
 
 function parsePostMessage(contentJson: string): ParsedFeishuMessage {
-  let post: { title?: unknown; content?: unknown } | null = null;
+  let post: { title?: unknown; content?: unknown };
   try {
     post = JSON.parse(contentJson) as { title?: unknown; content?: unknown };
   } catch {

--- a/electron/main/channels/feishu/feishu-content-parser.ts
+++ b/electron/main/channels/feishu/feishu-content-parser.ts
@@ -151,33 +151,6 @@ function parsePostMessage(contentJson: string): ParsedFeishuMessage {
 }
 
 /**
- * Detect image MIME type from a buffer's leading bytes ("magic numbers").
- * Returns null when the format is not recognized — callers should skip such images.
- */
-export function detectImageMime(buf: Buffer): string | null {
-  if (buf.length >= 8 &&
-      buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
-      buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a) {
-    return "image/png";
-  }
-  if (buf.length >= 3 &&
-      buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
-    return "image/jpeg";
-  }
-  if (buf.length >= 6 &&
-      buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38 &&
-      (buf[4] === 0x37 || buf[4] === 0x39) && buf[5] === 0x61) {
-    return "image/gif";
-  }
-  if (buf.length >= 12 &&
-      buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
-      buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50) {
-    return "image/webp";
-  }
-  return null;
-}
-
-/**
  * Build a MessagePromptContent[] from ordered parsed parts and a map of
  * already-downloaded image data keyed by image key. Parts whose image key is
  * missing from the map (e.g. download failed / size exceeded) are dropped.

--- a/electron/main/channels/feishu/feishu-transport.ts
+++ b/electron/main/channels/feishu/feishu-transport.ts
@@ -113,4 +113,46 @@ export class FeishuTransport implements MessageTransport {
       return "";
     }
   }
+
+  /**
+   * Download an image resource from a Feishu message and return the raw bytes.
+   * Aborts and returns null if the response stream exceeds `maxBytes` to guard
+   * against very large attachments. Returns null on any download error.
+   *
+   * The Lark SDK's `im.messageResource.get` returns a wrapper exposing
+   * `getReadableStream()` over the underlying HTTP stream.
+   */
+  async downloadMessageImage(
+    messageId: string,
+    fileKey: string,
+    maxBytes: number,
+  ): Promise<Buffer | null> {
+    try {
+      await this.rateLimiter.consume();
+      const res = await this.larkClient.im.messageResource.get({
+        params: { type: "image" },
+        path: { message_id: messageId, file_key: fileKey },
+      });
+      const stream = (res as any).getReadableStream();
+      const chunks: Buffer[] = [];
+      let total = 0;
+      for await (const raw of stream) {
+        const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw as ArrayBuffer);
+        total += chunk.length;
+        if (total > maxBytes) {
+          // Best-effort: drain remaining stream so the underlying socket can recycle.
+          try { stream.destroy?.(); } catch { /* ignore */ }
+          this.log.warn(
+            `Image ${fileKey} for message ${messageId} exceeds ${maxBytes} bytes — skipped`,
+          );
+          return null;
+        }
+        chunks.push(chunk);
+      }
+      return Buffer.concat(chunks, total);
+    } catch (err) {
+      this.log.error(`Failed to download image ${fileKey} for message ${messageId}:`, err);
+      return null;
+    }
+  }
 }

--- a/electron/main/channels/feishu/feishu-types.ts
+++ b/electron/main/channels/feishu/feishu-types.ts
@@ -4,7 +4,7 @@
 // Architecture: One Group Chat = One CodeMux Session
 // ============================================================================
 
-import type { EngineType, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
+import type { EngineType, MessagePromptContent, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
 import type { StreamingSession } from "../streaming/streaming-types";
 import { GATEWAY_PORT } from "../../../../shared/ports";
 
@@ -42,6 +42,12 @@ export const DEFAULT_FEISHU_CONFIG: FeishuConfig = {
 
 /** TTL for temporary P2P sessions (2 hours in ms) */
 export const TEMP_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+
+/** Per-image size cap for Feishu image downloads (mirrors frontend constraint). */
+export const MAX_FEISHU_IMAGE_BYTES = 3 * 1024 * 1024;
+
+/** Per-message cap on image attachments forwarded to engines. */
+export const MAX_FEISHU_IMAGES_PER_MESSAGE = 4;
 
 // --- Streaming State ---
 
@@ -104,9 +110,17 @@ export interface TempSession {
   /** Current streaming session (if any) */
   streamingSession?: StreamingSession;
   /** Message queue for serial processing */
-  messageQueue: string[];
+  messageQueue: QueuedFeishuMessage[];
   /** Whether currently processing a message */
   processing: boolean;
+}
+
+/** A queued Feishu user message awaiting engine dispatch. */
+export interface QueuedFeishuMessage {
+  /** Plain-text representation, used only for logging. */
+  text: string;
+  /** Ordered prompt content (text + image parts) sent to the engine. */
+  content: MessagePromptContent[];
 }
 
 /** Pending selection context for P2P text-based project/session selection */

--- a/electron/main/channels/feishu/feishu-types.ts
+++ b/electron/main/channels/feishu/feishu-types.ts
@@ -43,11 +43,13 @@ export const DEFAULT_FEISHU_CONFIG: FeishuConfig = {
 /** TTL for temporary P2P sessions (2 hours in ms) */
 export const TEMP_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 
-/** Per-image size cap for Feishu image downloads (mirrors frontend constraint). */
-export const MAX_FEISHU_IMAGE_BYTES = 3 * 1024 * 1024;
-
-/** Per-message cap on image attachments forwarded to engines. */
-export const MAX_FEISHU_IMAGES_PER_MESSAGE = 4;
+// Image limits are sourced from the shared module so frontend, channels, and
+// the gateway-side persistence path stay in sync.
+export {
+  MAX_IMAGE_SIZE_BYTES as MAX_FEISHU_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE as MAX_FEISHU_IMAGES_PER_MESSAGE,
+  MAX_TOTAL_IMAGE_BYTES as MAX_FEISHU_TOTAL_IMAGE_BYTES,
+} from "../../../../shared/image-limits";
 
 // --- Streaming State ---
 

--- a/electron/main/channels/shared/image-detector.ts
+++ b/electron/main/channels/shared/image-detector.ts
@@ -1,0 +1,41 @@
+// ============================================================================
+// Image format detection from magic bytes
+// Used by all channel adapters when downloading user-uploaded images so the
+// engine receives a correct `mimeType` regardless of what the upstream API
+// reports (some channels don't include reliable MIME headers).
+// ============================================================================
+
+export type DetectedImageMime = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+
+/**
+ * Detect an image's MIME type from its leading bytes. Returns null when the
+ * buffer doesn't match any supported format — callers should skip such images
+ * rather than pass them to the engine.
+ */
+export function detectImageMime(buf: Buffer): DetectedImageMime | null {
+  if (
+    buf.length >= 8 &&
+    buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+    buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (
+    buf.length >= 6 &&
+    buf[0] === 0x47 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x38 &&
+    (buf[4] === 0x37 || buf[4] === 0x39) && buf[5] === 0x61
+  ) {
+    return "image/gif";
+  }
+  if (
+    buf.length >= 12 &&
+    buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+    buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50
+  ) {
+    return "image/webp";
+  }
+  return null;
+}

--- a/electron/main/channels/teams/teams-adapter.ts
+++ b/electron/main/channels/teams/teams-adapter.ts
@@ -28,7 +28,7 @@ import {
 import { GatewayWsClient } from "../gateway-ws-client";
 import { StreamingController } from "../streaming/streaming-controller";
 import { TokenBucket } from "../streaming/rate-limiter";
-import { BaseSessionMapper, type PersistedBinding } from "../base-session-mapper";
+import { BaseSessionMapper, type BaseP2PChatState, type PersistedBinding } from "../base-session-mapper";
 import { createStreamingSession, type StreamingSession } from "../streaming/streaming-types";
 import { didConfigValuesChange, mergeDefinedConfig } from "../config-utils";
 import { TeamsTransport } from "./teams-transport";
@@ -49,7 +49,11 @@ import {
 } from "../shared/session-commands";
 import {
   DEFAULT_TEAMS_CONFIG,
+  MAX_TEAMS_IMAGE_BYTES,
+  MAX_TEAMS_IMAGES_PER_MESSAGE,
+  MAX_TEAMS_TOTAL_IMAGE_BYTES,
   TEMP_SESSION_TTL_MS,
+  type QueuedTeamsMessage,
   type TeamsConfig,
   type TeamsGroupBinding,
   type TeamsTempSession,
@@ -60,11 +64,13 @@ import {
 } from "./teams-types";
 import type {
   EngineType,
+  MessagePromptContent,
   UnifiedPart,
   UnifiedMessage,
   UnifiedPermission,
   UnifiedQuestion,
 } from "../../../../src/types/unified";
+import { detectImageMime } from "../shared/image-detector";
 import { channelLog } from "../../services/logger";
 import type { WebhookServer, WebhookRequest, WebhookResponse } from "../webhook-server";
 
@@ -74,7 +80,11 @@ const LOG_PREFIX = "[Teams]";
 // Teams Session Mapper (extends BaseSessionMapper with TeamsGroupBinding)
 // ============================================================================
 
-class TeamsSessionMapper extends BaseSessionMapper<TeamsGroupBinding> {
+class TeamsSessionMapper extends BaseSessionMapper<
+  TeamsGroupBinding,
+  BaseP2PChatState,
+  TeamsTempSession
+> {
   constructor() {
     super("teams");
   }
@@ -393,9 +403,18 @@ export class TeamsAdapter extends ChannelAdapter {
   private async handleMessage(activity: TeamsActivity): Promise<void> {
     const { from, conversation, text } = activity;
 
-    // Skip messages without text or from the bot itself
-    if (!text || !from) return;
+    // Skip messages from the bot itself
+    if (!from) return;
     if (from.id === activity.recipient?.id) return;
+
+    // Detect inbound image attachments (Teams sends images as attachments with
+    // an image/* contentType plus a Bearer-protected contentUrl).
+    const imageAttachments = (activity.attachments || []).filter(
+      (a) => a.contentType?.startsWith("image/") && a.contentUrl,
+    );
+    const hasImage = imageAttachments.length > 0;
+    const textOrEmpty = (text ?? "").trim();
+    if (!textOrEmpty && !hasImage) return;
 
     // Deduplication
     const dedupKey = `${conversation.id}:${activity.id}`;
@@ -411,7 +430,7 @@ export class TeamsAdapter extends ChannelAdapter {
 
     channelLog.info(
       `${LOG_PREFIX} Message from ${convType} ` +
-      `(${displayName}): ${text.slice(0, 100)}`,
+      `(${displayName}): ${textOrEmpty.slice(0, 100)}${hasImage ? ` [+${imageAttachments.length} image]` : ""}`,
     );
 
     if (convType === "personal") {
@@ -419,20 +438,72 @@ export class TeamsAdapter extends ChannelAdapter {
       const p2p = this.sessionMapper.getOrCreateP2PChat(chatId, userId);
       (p2p as any).displayName = displayName;
       this.sessionMapper.setUserIdMapping(userId, chatId);
-      await this.handleP2PMessage(chatId, userId, text);
+
+      const promptContent = await this.buildEngineContent(chatId, textOrEmpty, imageAttachments);
+      if (promptContent.length === 0) return;
+      await this.handleP2PMessage(chatId, userId, textOrEmpty, promptContent);
     } else {
       // Group or channel message
       const botId = activity.recipient?.id || this.config.microsoftAppId;
       const hasMention = this.isBotMentioned(activity, botId);
-      const isCommand = text.trim().startsWith("/");
+      const isCommand = textOrEmpty.startsWith("/");
       const hasPending = !!this.sessionMapper.getPendingSelection(chatId);
       const hasPendingQuestion = !!this.sessionMapper.getPendingQuestion(chatId);
 
       if (hasMention || isCommand || hasPending || hasPendingQuestion) {
-        const content = this.stripMentions(text);
-        await this.handleGroupMessage(chatId, content, activity.serviceUrl);
+        const stripped = this.stripMentions(textOrEmpty);
+        const promptContent = await this.buildEngineContent(chatId, stripped, imageAttachments, activity.serviceUrl);
+        if (promptContent.length === 0) return;
+        await this.handleGroupMessage(chatId, stripped, promptContent, activity.serviceUrl);
       }
     }
+  }
+
+  /**
+   * Build a MessagePromptContent[] payload from a Teams activity by downloading
+   * each image attachment via the Bot Framework Bearer token. Enforces
+   * per-image, per-message-count, and total-byte limits.
+   */
+  private async buildEngineContent(
+    chatId: string,
+    text: string,
+    attachments: Array<{ contentType: string; contentUrl?: string; name?: string }>,
+    serviceUrl?: string,
+  ): Promise<MessagePromptContent[]> {
+    const out: MessagePromptContent[] = [];
+    if (text) out.push({ type: "text", text });
+
+    if (!this.transport || attachments.length === 0) return out;
+
+    // Cap number of images per message.
+    const selected = attachments.slice(0, MAX_TEAMS_IMAGES_PER_MESSAGE);
+    if (attachments.length > MAX_TEAMS_IMAGES_PER_MESSAGE) {
+      await this.transport.sendText(
+        chatId,
+        `⚠️ 一次最多接受 ${MAX_TEAMS_IMAGES_PER_MESSAGE} 张图片，已忽略多余部分`,
+      );
+    }
+
+    if (serviceUrl) this.transport.setServiceUrl(chatId, serviceUrl);
+
+    let totalBytes = 0;
+    for (const att of selected) {
+      if (!att.contentUrl) continue;
+      const buf = await this.transport.downloadFromUrl(att.contentUrl, MAX_TEAMS_IMAGE_BYTES);
+      if (!buf) {
+        await this.transport.sendText(chatId, `⚠️ 图片下载失败：${att.name || "image"}`);
+        continue;
+      }
+      if (totalBytes + buf.length > MAX_TEAMS_TOTAL_IMAGE_BYTES) {
+        await this.transport.sendText(chatId, "⚠️ 图片总大小超过限制");
+        break;
+      }
+      const mimeType = detectImageMime(buf) || att.contentType || "image/png";
+      out.push({ type: "image", data: buf.toString("base64"), mimeType });
+      totalBytes += buf.length;
+    }
+
+    return out;
   }
 
   /**
@@ -571,6 +642,7 @@ export class TeamsAdapter extends ChannelAdapter {
     chatId: string,
     userId: string,
     text: string,
+    content: MessagePromptContent[],
   ): Promise<void> {
     // 1. Check for slash commands first
     const command = parseCommand(text);
@@ -609,7 +681,7 @@ export class TeamsAdapter extends ChannelAdapter {
     // 4. Active temp session (not expired)? → send to engine
     const tempSession = this.sessionMapper.getTempSession(chatId);
     if (tempSession && !this.isTempSessionExpired(tempSession)) {
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content);
       return;
     }
 
@@ -623,6 +695,8 @@ export class TeamsAdapter extends ChannelAdapter {
         chatId,
         p2pState.lastSelectedProject,
         text,
+        undefined,
+        content,
       );
       return;
     }
@@ -640,7 +714,7 @@ export class TeamsAdapter extends ChannelAdapter {
           engineType: defaultProject.engineType,
           projectId: defaultProject.id,
         };
-        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区", content);
         return;
       }
     }
@@ -857,6 +931,7 @@ export class TeamsAdapter extends ChannelAdapter {
     },
     text: string,
     projectName?: string,
+    content?: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -879,7 +954,7 @@ export class TeamsAdapter extends ChannelAdapter {
       this.sessionMapper.setTempSession(chatId, tempSession);
       const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
       await this.transport!.sendMarkdown(chatId, buildSessionNotification(name, session.engineType, session.id));
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content ?? [{ type: "text", text }]);
     } catch (err) {
       await this.transport!.sendMarkdown(
         chatId,
@@ -892,11 +967,12 @@ export class TeamsAdapter extends ChannelAdapter {
   private async enqueueP2PMessage(
     chatId: string,
     text: string,
+    content: MessagePromptContent[],
   ): Promise<void> {
     const temp = this.sessionMapper.getTempSession(chatId);
     if (!temp) return;
 
-    temp.messageQueue.push(text);
+    temp.messageQueue.push({ text, content });
     if (!temp.processing) {
       await this.processP2PQueue(chatId);
     }
@@ -911,15 +987,15 @@ export class TeamsAdapter extends ChannelAdapter {
     }
 
     temp.processing = true;
-    const text = temp.messageQueue.shift()!;
-    await this.sendToEngineP2P(chatId, temp, text);
+    const queued = temp.messageQueue.shift()!;
+    await this.sendToEngineP2P(chatId, temp, queued);
   }
 
   /** Send a message to the engine via a P2P temp session */
   private async sendToEngineP2P(
     chatId: string,
     tempSession: TeamsTempSession,
-    text: string,
+    queued: QueuedTeamsMessage,
   ): Promise<void> {
     if (
       !this.gatewayClient ||
@@ -949,7 +1025,7 @@ export class TeamsAdapter extends ChannelAdapter {
 
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: tempSession.conversationId,
-      content: [{ type: "text", text }],
+      content: queued.content,
     });
 
     sendPromise
@@ -1101,6 +1177,7 @@ export class TeamsAdapter extends ChannelAdapter {
   private async handleGroupMessage(
     groupChatId: string,
     text: string,
+    content: MessagePromptContent[],
     serviceUrl: string,
   ): Promise<void> {
     const binding = this.sessionMapper.getGroupBinding(groupChatId);
@@ -1158,7 +1235,7 @@ export class TeamsAdapter extends ChannelAdapter {
     }
 
     // Regular message → send to engine
-    await this.sendToEngine(groupChatId, binding, text);
+    await this.sendToEngine(groupChatId, binding, content);
   }
 
   /** Show project list for group binding selection */
@@ -1377,7 +1454,7 @@ export class TeamsAdapter extends ChannelAdapter {
   private async sendToEngine(
     groupChatId: string,
     binding: TeamsGroupBinding,
-    text: string,
+    content: MessagePromptContent[],
   ): Promise<void> {
     if (
       !this.gatewayClient ||
@@ -1412,7 +1489,7 @@ export class TeamsAdapter extends ChannelAdapter {
     // Send message to engine via Gateway (non-blocking)
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: binding.conversationId,
-      content: [{ type: "text", text }],
+      content,
     });
 
     sendPromise

--- a/electron/main/channels/teams/teams-transport.ts
+++ b/electron/main/channels/teams/teams-transport.ts
@@ -316,4 +316,43 @@ export class TeamsTransport implements MessageTransport {
 
     return res.json();
   }
+
+  /**
+   * Download a binary asset by URL. Teams attachment contentUrls usually
+   * require a Bearer token (same one used to call the Bot Framework API).
+   * If the unauthenticated request succeeds (e.g. public CDN) we use that;
+   * otherwise we retry with the token. Returns null on failure or when the
+   * payload exceeds maxBytes.
+   */
+  async downloadFromUrl(url: string, maxBytes: number): Promise<Buffer | null> {
+    if (!url) return null;
+    try {
+      // Try without auth first (some Teams URLs are short-lived public links).
+      let res = await fetch(url);
+      if (res.status === 401 || res.status === 403) {
+        const token = await this.tokenManager.getToken();
+        res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+      }
+      if (!res.ok) {
+        channelLog.warn(`${LOG_PREFIX} downloadFromUrl ${res.status} for ${url}`);
+        return null;
+      }
+
+      const len = res.headers.get("content-length");
+      if (len && Number(len) > maxBytes) {
+        channelLog.warn(`${LOG_PREFIX} downloadFromUrl exceeds limit (${len} > ${maxBytes})`);
+        return null;
+      }
+
+      const buf = Buffer.from(await res.arrayBuffer());
+      if (buf.length > maxBytes) {
+        channelLog.warn(`${LOG_PREFIX} downloadFromUrl actual size exceeds limit (${buf.length})`);
+        return null;
+      }
+      return buf;
+    } catch (err) {
+      channelLog.error(`${LOG_PREFIX} downloadFromUrl failed:`, err);
+      return null;
+    }
+  }
 }

--- a/electron/main/channels/teams/teams-types.ts
+++ b/electron/main/channels/teams/teams-types.ts
@@ -8,8 +8,13 @@
 // Auth: Azure AD App Registration (App ID + App Password).
 // ============================================================================
 
-import type { EngineType, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
+import type { EngineType, MessagePromptContent, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
 import type { BaseGroupBinding } from "../base-session-mapper";
+import {
+  MAX_IMAGE_SIZE_BYTES,
+  MAX_IMAGES_PER_MESSAGE,
+  MAX_TOTAL_IMAGE_BYTES,
+} from "../../../../shared/image-limits";
 
 // Re-export shared streaming types for convenience
 export type { StreamingSession } from "../streaming/streaming-types";
@@ -47,6 +52,18 @@ export const DEFAULT_TEAMS_CONFIG: TeamsConfig = {
 
 /** TTL for temporary P2P sessions (2 hours in ms) */
 export const TEMP_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+
+// --- Image attachment limits (shared with frontend) ---
+
+export const MAX_TEAMS_IMAGE_BYTES = MAX_IMAGE_SIZE_BYTES;
+export const MAX_TEAMS_IMAGES_PER_MESSAGE = MAX_IMAGES_PER_MESSAGE;
+export const MAX_TEAMS_TOTAL_IMAGE_BYTES = MAX_TOTAL_IMAGE_BYTES;
+
+/** A queued P2P message carrying both text and any decoded attachments. */
+export interface QueuedTeamsMessage {
+  text: string;
+  content: MessagePromptContent[];
+}
 
 // --- Group Binding ---
 
@@ -95,7 +112,7 @@ export interface TeamsTempSession {
   /** Current streaming session (if any) */
   streamingSession?: import("../streaming/streaming-types").StreamingSession;
   /** Message queue for serial processing */
-  messageQueue: string[];
+  messageQueue: QueuedTeamsMessage[];
   /** Whether currently processing a message */
   processing: boolean;
 }
@@ -143,8 +160,13 @@ export interface TeamsActivity {
   text?: string;
   /** Text format (e.g., "plain", "markdown") */
   textFormat?: string;
-  /** Attachments (e.g., Adaptive Cards) */
-  attachments?: Array<{ contentType: string; content: unknown }>;
+  /** Attachments (e.g., Adaptive Cards, files, images) */
+  attachments?: Array<{
+    contentType: string;
+    content?: unknown;
+    contentUrl?: string;
+    name?: string;
+  }>;
   /** Entities (e.g., @mentions) */
   entities?: Array<{
     type: string;

--- a/electron/main/channels/telegram/telegram-adapter.ts
+++ b/electron/main/channels/telegram/telegram-adapter.ts
@@ -26,7 +26,7 @@ import {
 import { GatewayWsClient } from "../gateway-ws-client";
 import { StreamingController } from "../streaming/streaming-controller";
 import { TokenBucket } from "../streaming/rate-limiter";
-import { BaseSessionMapper } from "../base-session-mapper";
+import { BaseSessionMapper, type BaseP2PChatState } from "../base-session-mapper";
 import { createStreamingSession, type StreamingSession } from "../streaming/streaming-types";
 import { TelegramTransport } from "./telegram-transport";
 import { TelegramRenderer } from "./telegram-renderer";
@@ -45,6 +45,8 @@ import { handleSessionOpsCommand, type SessionContext } from "../shared/session-
 import {
   DEFAULT_TELEGRAM_CONFIG,
   TEMP_SESSION_TTL_MS,
+  MAX_TELEGRAM_IMAGE_BYTES,
+  MAX_TELEGRAM_TOTAL_IMAGE_BYTES,
   type TelegramConfig,
   type TelegramGroupBinding,
   type TelegramTempSession,
@@ -52,15 +54,18 @@ import {
   type TelegramUpdate,
   type TelegramMessage,
   type TelegramCallbackQuery,
+  type QueuedTelegramMessage,
 } from "./telegram-types";
 import type {
   EngineType,
+  MessagePromptContent,
   UnifiedPart,
   UnifiedMessage,
   UnifiedPermission,
   UnifiedQuestion,
 } from "../../../../src/types/unified";
 import { channelLog } from "../../services/logger";
+import { detectImageMime } from "../shared/image-detector";
 import type { WebhookServer, WebhookRequest, WebhookResponse } from "../webhook-server";
 
 const LOG_PREFIX = "[Telegram]";
@@ -69,7 +74,11 @@ const LOG_PREFIX = "[Telegram]";
 // Telegram Session Mapper (uses BaseSessionMapper with TelegramGroupBinding)
 // ============================================================================
 
-class TelegramSessionMapper extends BaseSessionMapper<TelegramGroupBinding> {
+class TelegramSessionMapper extends BaseSessionMapper<
+  TelegramGroupBinding,
+  BaseP2PChatState,
+  TelegramTempSession
+> {
   constructor() {
     super("telegram");
   }
@@ -442,10 +451,16 @@ export class TelegramAdapter extends ChannelAdapter {
   }
 
   private async handleTelegramMessage(message: TelegramMessage): Promise<void> {
-    const { message_id, from, chat, text } = message;
+    const { message_id, from, chat, text, caption, photo, document } = message;
 
-    // Skip messages without text or from bots
-    if (!text || !from || from.is_bot) return;
+    // Skip messages from bots
+    if (!from || from.is_bot) return;
+
+    // Determine if this message carries an image attachment we accept.
+    const isImageDocument = Boolean(document?.mime_type?.startsWith("image/"));
+    const hasImage = Boolean((photo && photo.length > 0) || isImageDocument);
+    const textOrCaption = (text ?? caption ?? "").trim();
+    if (!textOrCaption && !hasImage) return;
 
     // Deduplication
     const dedupKey = `${chat.id}:${message_id}`;
@@ -460,7 +475,7 @@ export class TelegramAdapter extends ChannelAdapter {
 
     channelLog.info(
       `${LOG_PREFIX} Message from ${chat.type} ` +
-      `(${displayName}): ${text.slice(0, 100)}`,
+      `(${displayName}): ${textOrCaption.slice(0, 100)}${hasImage ? " [+image]" : ""}`,
     );
 
     if (chat.type === "private") {
@@ -468,14 +483,64 @@ export class TelegramAdapter extends ChannelAdapter {
       const p2p = this.sessionMapper.getOrCreateP2PChat(chatId, userId);
       (p2p as any).displayName = displayName;
       this.sessionMapper.setUserIdMapping(userId, chatId);
-      await this.handleP2PMessage(chatId, userId, text);
+
+      const content = await this.buildEngineContent(chatId, textOrCaption, message);
+      if (content.length === 0) return;
+      await this.handleP2PMessage(chatId, userId, textOrCaption, content);
     } else if (chat.type === "group" || chat.type === "supergroup") {
-      // Group message — only process if bot is mentioned or it's a command
-      if (this.isBotMentioned(message) || text.startsWith("/")) {
-        const content = this.stripBotMention(text);
-        await this.handleGroupMessage(chatId, content);
+      // Group message — only process if bot is mentioned or it's a command.
+      // For images, we still require a caption that mentions the bot (or a
+      // reply chain TODO) to avoid noise; otherwise text-only mention rules.
+      if (this.isBotMentioned(message) || textOrCaption.startsWith("/")) {
+        const stripped = this.stripBotMention(textOrCaption);
+        const content = await this.buildEngineContent(chatId, stripped, message);
+        if (content.length === 0) return;
+        await this.handleGroupMessage(chatId, stripped, content);
       }
     }
+  }
+
+  /**
+   * Build a MessagePromptContent[] payload from a Telegram message.
+   * Downloads the largest photo size (or document image) and applies
+   * size/MIME/total-bytes limits. Plain-text messages take the fast path.
+   */
+  private async buildEngineContent(
+    chatId: string,
+    text: string,
+    message: TelegramMessage,
+  ): Promise<MessagePromptContent[]> {
+    const out: MessagePromptContent[] = [];
+    if (text) out.push({ type: "text", text });
+
+    if (!this.transport) return out;
+
+    // Prefer the highest-resolution photo; fall back to a document image.
+    let fileId: string | undefined;
+    if (message.photo && message.photo.length > 0) {
+      // Telegram orders photos smallest → largest; pick the last entry.
+      fileId = message.photo[message.photo.length - 1].file_id;
+    } else if (message.document?.mime_type?.startsWith("image/")) {
+      fileId = message.document.file_id;
+    }
+    if (!fileId) return out;
+
+    const buf = await this.transport.downloadFile(fileId, MAX_TELEGRAM_IMAGE_BYTES);
+    if (!buf) {
+      await this.transport.sendText(chatId, "⚠️ 图片下载失败或超过大小限制");
+      return out;
+    }
+    if (buf.length > MAX_TELEGRAM_TOTAL_IMAGE_BYTES) {
+      await this.transport.sendText(chatId, "⚠️ 图片总大小超过限制");
+      return out;
+    }
+    const mimeType = detectImageMime(buf);
+    if (!mimeType) {
+      await this.transport.sendText(chatId, "⚠️ 不支持的图片格式");
+      return out;
+    }
+    out.push({ type: "image", data: buf.toString("base64"), mimeType });
+    return out;
   }
 
   /**
@@ -594,7 +659,12 @@ export class TelegramAdapter extends ChannelAdapter {
   // P2P Message Handling (Primary Interaction Mode)
   // ============================================================================
 
-  private async handleP2PMessage(chatId: string, userId: string, text: string): Promise<void> {
+  private async handleP2PMessage(
+    chatId: string,
+    userId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     // 1. Check for slash commands first
     const command = parseCommand(text);
     if (command) {
@@ -625,7 +695,7 @@ export class TelegramAdapter extends ChannelAdapter {
     // 4. Active temp session (not expired)? → send to engine
     const tempSession = this.sessionMapper.getTempSession(chatId);
     if (tempSession && !this.isTempSessionExpired(tempSession)) {
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content);
       return;
     }
 
@@ -635,7 +705,7 @@ export class TelegramAdapter extends ChannelAdapter {
       if (tempSession) {
         await this.cleanupExpiredTempSession(chatId);
       }
-      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text);
+      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text, undefined, content);
       return;
     }
 
@@ -652,7 +722,7 @@ export class TelegramAdapter extends ChannelAdapter {
           engineType: defaultProject.engineType,
           projectId: defaultProject.id,
         };
-        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区", content);
         return;
       }
     }
@@ -852,6 +922,7 @@ export class TelegramAdapter extends ChannelAdapter {
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
     projectName?: string,
+    content?: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -876,7 +947,7 @@ export class TelegramAdapter extends ChannelAdapter {
       const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
       await this.transport!.sendMarkdown(chatId, buildSessionNotification(name, session.engineType, session.id));
 
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content ?? [{ type: "text", text }]);
     } catch (err) {
       await this.transport!.sendMarkdown(
         chatId,
@@ -886,11 +957,15 @@ export class TelegramAdapter extends ChannelAdapter {
   }
 
   /** Enqueue a message for serial processing in the P2P temp session */
-  private async enqueueP2PMessage(chatId: string, text: string): Promise<void> {
+  private async enqueueP2PMessage(
+    chatId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     const temp = this.sessionMapper.getTempSession(chatId);
     if (!temp) return;
 
-    temp.messageQueue.push(text);
+    temp.messageQueue.push({ text, content });
     if (!temp.processing) {
       await this.processP2PQueue(chatId);
     }
@@ -905,15 +980,15 @@ export class TelegramAdapter extends ChannelAdapter {
     }
 
     temp.processing = true;
-    const text = temp.messageQueue.shift()!;
-    await this.sendToEngineP2P(chatId, temp, text);
+    const queued = temp.messageQueue.shift()!;
+    await this.sendToEngineP2P(chatId, temp, queued);
   }
 
   /** Send a message to the engine via a P2P temp session */
   private async sendToEngineP2P(
     chatId: string,
     tempSession: TelegramTempSession,
-    text: string,
+    queued: QueuedTelegramMessage,
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) {
       tempSession.processing = false;
@@ -936,7 +1011,7 @@ export class TelegramAdapter extends ChannelAdapter {
 
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: tempSession.conversationId,
-      content: [{ type: "text", text }],
+      content: queued.content,
     });
 
     sendPromise
@@ -1073,7 +1148,11 @@ export class TelegramAdapter extends ChannelAdapter {
   // Group Message Handling
   // ============================================================================
 
-  private async handleGroupMessage(groupChatId: string, text: string): Promise<void> {
+  private async handleGroupMessage(
+    groupChatId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     const binding = this.sessionMapper.getGroupBinding(groupChatId);
 
     if (!binding) {
@@ -1115,7 +1194,7 @@ export class TelegramAdapter extends ChannelAdapter {
     }
 
     // Regular message → send to engine
-    await this.sendToEngine(groupChatId, binding, text);
+    await this.sendToEngine(groupChatId, binding, content);
   }
 
   /** Show project list for group binding selection */
@@ -1177,7 +1256,7 @@ export class TelegramAdapter extends ChannelAdapter {
   private async sendToEngine(
     groupChatId: string,
     binding: TelegramGroupBinding,
-    text: string,
+    content: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) return;
 
@@ -1202,7 +1281,7 @@ export class TelegramAdapter extends ChannelAdapter {
     // Send message to engine via Gateway (non-blocking)
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: binding.conversationId,
-      content: [{ type: "text", text }],
+      content,
     });
 
     sendPromise

--- a/electron/main/channels/telegram/telegram-transport.ts
+++ b/electron/main/channels/telegram/telegram-transport.ts
@@ -398,6 +398,37 @@ export class TelegramTransport implements MessageTransport {
       msgId: compoundId.slice(colonIdx + 1),
     };
   }
+
+  // =========================================================================
+  // File Download (for inbound images)
+  // =========================================================================
+
+  /**
+   * Download a file by Telegram file_id. Calls `getFile` to retrieve the
+   * relative file_path, then fetches the binary from the file CDN. Aborts
+   * when the body exceeds `maxBytes` to keep memory bounded.
+   */
+  async downloadFile(fileId: string, maxBytes: number): Promise<Buffer | null> {
+    try {
+      const meta = await this.callApi("getFile", { file_id: fileId });
+      const filePath = (meta?.result as { file_path?: string } | undefined)?.file_path;
+      if (!filePath) {
+        return null;
+      }
+      const fileUrl = `https://api.telegram.org/file/bot${this.botToken}/${filePath}`;
+      const res = await fetch(fileUrl);
+      if (!res.ok) return null;
+      const contentLength = res.headers.get("content-length");
+      if (contentLength && parseInt(contentLength, 10) > maxBytes) {
+        return null;
+      }
+      const ab = await res.arrayBuffer();
+      if (ab.byteLength > maxBytes) return null;
+      return Buffer.from(ab);
+    } catch {
+      return null;
+    }
+  }
 }
 
 // ============================================================================

--- a/electron/main/channels/telegram/telegram-types.ts
+++ b/electron/main/channels/telegram/telegram-types.ts
@@ -5,7 +5,7 @@
 // Group chats are supported when bot is added by user — bot cannot create groups.
 // ============================================================================
 
-import type { EngineType, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
+import type { EngineType, MessagePromptContent, UnifiedProject, UnifiedSession } from "../../../../src/types/unified";
 import type { BaseGroupBinding } from "../base-session-mapper";
 
 // Re-export shared streaming types for convenience
@@ -44,6 +44,26 @@ export const DEFAULT_TELEGRAM_CONFIG: TelegramConfig = {
 
 /** TTL for temporary P2P sessions (2 hours in ms) */
 export const TEMP_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
+
+// Image limits are sourced from the shared module so frontend, channels, and
+// the gateway-side persistence path stay in sync.
+export {
+  MAX_IMAGE_SIZE_BYTES as MAX_TELEGRAM_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE as MAX_TELEGRAM_IMAGES_PER_MESSAGE,
+  MAX_TOTAL_IMAGE_BYTES as MAX_TELEGRAM_TOTAL_IMAGE_BYTES,
+} from "../../../../shared/image-limits";
+
+/**
+ * A queued Telegram user message awaiting engine dispatch. Carries
+ * already-built MessagePromptContent so the queue worker can call
+ * sendMessage directly without re-downloading images.
+ */
+export interface QueuedTelegramMessage {
+  /** Plain-text preview for logging only. */
+  text: string;
+  /** Ordered prompt content (text + image parts) sent to the engine. */
+  content: MessagePromptContent[];
+}
 
 // --- Group Binding ---
 
@@ -91,7 +111,7 @@ export interface TelegramTempSession {
   /** Current streaming session (if any) */
   streamingSession?: import("../streaming/streaming-types").StreamingSession;
   /** Message queue for serial processing */
-  messageQueue: string[];
+  messageQueue: QueuedTelegramMessage[];
   /** Whether currently processing a message */
   processing: boolean;
 }
@@ -133,6 +153,31 @@ export interface TelegramMessage {
   };
   date: number;
   text?: string;
+  /** Caption present when the message is a photo/document carrying a description. */
+  caption?: string;
+  /**
+   * Photo sizes (smallest → largest). We use the largest entry for fidelity.
+   * Empty array when the message is not a photo.
+   */
+  photo?: Array<{
+    file_id: string;
+    file_unique_id: string;
+    width: number;
+    height: number;
+    file_size?: number;
+  }>;
+  /**
+   * Document attachment — Telegram delivers images as `document` when the
+   * sender opts out of recompression (e.g. PNG with transparency). We only
+   * accept ones whose `mime_type` starts with `image/`.
+   */
+  document?: {
+    file_id: string;
+    file_unique_id: string;
+    file_name?: string;
+    mime_type?: string;
+    file_size?: number;
+  };
   entities?: Array<{
     type: string;
     offset: number;

--- a/electron/main/channels/wecom/wecom-adapter.ts
+++ b/electron/main/channels/wecom/wecom-adapter.ts
@@ -24,7 +24,7 @@ import { StreamingController } from "../streaming/streaming-controller";
 import { TokenManager } from "../streaming/token-manager";
 import { TokenBucket } from "../streaming/rate-limiter";
 import { createStreamingSession, type StreamingSession } from "../streaming/streaming-types";
-import { BaseSessionMapper, type BaseGroupBinding, type BaseTempSession, type BasePendingSelection, type PersistedBinding } from "../base-session-mapper";
+import { BaseSessionMapper, type BaseGroupBinding, type BaseP2PChatState, type BaseTempSession, type BasePendingSelection, type PersistedBinding } from "../base-session-mapper";
 import { didConfigValuesChange, mergeDefinedConfig } from "../config-utils";
 import type { WebhookServer, WebhookRequest, WebhookResponse } from "../webhook-server";
 import { WeComCrypto } from "./wecom-crypto";
@@ -44,18 +44,23 @@ import { handleSessionOpsCommand, type SessionContext } from "../shared/session-
 import {
   DEFAULT_WECOM_CONFIG,
   TEMP_SESSION_TTL_MS,
+  MAX_WECOM_IMAGE_BYTES,
+  MAX_WECOM_TOTAL_IMAGE_BYTES,
   type WeComConfig,
   type WeComGroupBinding,
   type WeComIncomingMessage,
+  type QueuedWeComMessage,
 } from "./wecom-types";
 import type {
   EngineType,
+  MessagePromptContent,
   UnifiedPart,
   UnifiedMessage,
   UnifiedPermission,
   UnifiedQuestion,
 } from "../../../../src/types/unified";
 import { channelLog } from "../../services/logger";
+import { detectImageMime } from "../shared/image-detector";
 
 // ============================================================================
 // XML Parsing Helper
@@ -85,7 +90,11 @@ interface WeComPersistedBinding extends PersistedBinding {
   ownerUserId: string;
 }
 
-class WeComSessionMapper extends BaseSessionMapper<WeComGroupBinding> {
+class WeComSessionMapper extends BaseSessionMapper<
+  WeComGroupBinding,
+  BaseP2PChatState,
+  BaseTempSession<QueuedWeComMessage>
+> {
   protected override deserializeBinding(item: PersistedBinding): WeComGroupBinding {
     const base = super.deserializeBinding(item);
     return {
@@ -451,6 +460,8 @@ export class WeComAdapter extends ChannelAdapter {
       content: fields["Content"],
       msgId: fields["MsgId"] ?? "",
       agentId: parseInt(fields["AgentID"] ?? "0", 10),
+      picUrl: fields["PicUrl"],
+      mediaId: fields["MediaId"],
     };
 
     // Process asynchronously, respond immediately to WeCom
@@ -466,9 +477,9 @@ export class WeComAdapter extends ChannelAdapter {
   // =========================================================================
 
   private async processIncomingMessage(msg: WeComIncomingMessage): Promise<void> {
-    // Skip non-text messages
-    if (msg.msgType !== "text") {
-      channelLog.verbose(`[WeCom] Ignoring non-text message type: ${msg.msgType}`);
+    // Accept text and image; everything else (voice/video/...) is dropped.
+    if (msg.msgType !== "text" && msg.msgType !== "image") {
+      channelLog.verbose(`[WeCom] Ignoring non-text/image message type: ${msg.msgType}`);
       return;
     }
 
@@ -480,29 +491,68 @@ export class WeComAdapter extends ChannelAdapter {
 
     const userId = msg.fromUserName;
     const text = (msg.content ?? "").trim();
-    if (!text) return;
+    const hasImage = msg.msgType === "image" && Boolean(msg.picUrl);
+    if (!text && !hasImage) return;
 
-    channelLog.info(`[WeCom] Message from ${userId}: ${text.slice(0, 100)}`);
+    channelLog.info(
+      `[WeCom] Message from ${userId}: ${text.slice(0, 100)}${hasImage ? " [+image]" : ""}`,
+    );
 
-    // WeCom doesn't have native P2P vs group distinction in callback;
-    // we use our userId-based P2P state to determine routing.
-    // If the userId matches a known group binding member, route to group handling.
-    // Otherwise, treat as P2P message.
     const chatId = `user:${userId}`;
-
-    // Check if user has an active group context
-    // For WeCom, all callback messages come to the same endpoint.
-    // We always treat callback messages as P2P (user→bot direct messages).
-    // Group chat interactions happen when the bot sends to a group.
     this.sessionMapper.getOrCreateP2PChat(chatId, userId);
-    await this.handleP2PMessage(chatId, userId, text);
+
+    // Build engine content once at entry — WeCom delivers a single image per
+    // event, so we don't need queue/loop machinery here.
+    const content = await this.buildEngineContent(chatId, text, msg);
+    if (content.length === 0) return;
+
+    await this.handleP2PMessage(chatId, userId, text, content);
+  }
+
+  /**
+   * Build a MessagePromptContent[] payload from a WeCom event. Downloads the
+   * image (when present) and applies size/MIME/total-bytes limits. Plain-text
+   * messages take the fast path with no async work.
+   */
+  private async buildEngineContent(
+    chatId: string,
+    text: string,
+    msg: WeComIncomingMessage,
+  ): Promise<MessagePromptContent[]> {
+    const out: MessagePromptContent[] = [];
+    if (text) out.push({ type: "text", text });
+
+    if (msg.msgType !== "image" || !msg.picUrl) return out;
+    if (!this.transport) return out;
+
+    const buf = await this.transport.downloadImageFromUrl(msg.picUrl, MAX_WECOM_IMAGE_BYTES);
+    if (!buf) {
+      await this.transport.sendText(chatId, "⚠️ 图片下载失败");
+      return out;
+    }
+    if (buf.length > MAX_WECOM_TOTAL_IMAGE_BYTES) {
+      await this.transport.sendText(chatId, "⚠️ 图片总大小超过限制");
+      return out;
+    }
+    const mimeType = detectImageMime(buf);
+    if (!mimeType) {
+      await this.transport.sendText(chatId, "⚠️ 不支持的图片格式");
+      return out;
+    }
+    out.push({ type: "image", data: buf.toString("base64"), mimeType });
+    return out;
   }
 
   // =========================================================================
   // P2P Message Handling
   // =========================================================================
 
-  private async handleP2PMessage(chatId: string, userId: string, text: string): Promise<void> {
+  private async handleP2PMessage(
+    chatId: string,
+    userId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     // 1. Check for slash commands
     const command = parseCommand(text);
     if (command) {
@@ -533,7 +583,7 @@ export class WeComAdapter extends ChannelAdapter {
     // 4. Active temp session?
     const tempSession = this.sessionMapper.getTempSession(chatId);
     if (tempSession && !this.isTempSessionExpired(tempSession)) {
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content);
       return;
     }
 
@@ -543,7 +593,7 @@ export class WeComAdapter extends ChannelAdapter {
       if (tempSession) {
         await this.cleanupExpiredTempSession(chatId);
       }
-      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text);
+      await this.createTempSessionAndSend(chatId, p2pState.lastSelectedProject, text, undefined, content);
       return;
     }
 
@@ -560,7 +610,7 @@ export class WeComAdapter extends ChannelAdapter {
           engineType: defaultProject.engineType,
           projectId: defaultProject.id,
         };
-        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区");
+        await this.createTempSessionAndSend(chatId, defaultRef, text, "默认工作区", content);
         return;
       }
     }
@@ -722,7 +772,7 @@ export class WeComAdapter extends ChannelAdapter {
       // WeCom's appchat/create API requires at least 2 members, so we cannot
       // create a 1-on-1 group chat like Feishu.  Instead, use P2P temp session
       // mode: messages are exchanged directly in the user↔bot chat.
-      const tempSession: BaseTempSession = {
+      const tempSession: BaseTempSession<QueuedWeComMessage> = {
         conversationId: session.id,
         engineType: session.engineType,
         directory: project.directory,
@@ -822,7 +872,7 @@ export class WeComAdapter extends ChannelAdapter {
     }
 
     // Use P2P temp session instead of group chat (WeCom requires ≥2 members for groups)
-    const tempSession: BaseTempSession = {
+    const tempSession: BaseTempSession<QueuedWeComMessage> = {
       conversationId: session.id,
       engineType: session.engineType,
       directory: pending.directory,
@@ -846,7 +896,7 @@ export class WeComAdapter extends ChannelAdapter {
   // P2P Temp Session Methods
   // =========================================================================
 
-  private isTempSessionExpired(temp: BaseTempSession): boolean {
+  private isTempSessionExpired(temp: BaseTempSession<QueuedWeComMessage>): boolean {
     return Date.now() - temp.lastActiveAt > TEMP_SESSION_TTL_MS;
   }
 
@@ -855,6 +905,7 @@ export class WeComAdapter extends ChannelAdapter {
     project: { directory: string; engineType?: EngineType; projectId: string },
     text: string,
     projectName?: string,
+    content?: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient) return;
 
@@ -864,7 +915,7 @@ export class WeComAdapter extends ChannelAdapter {
         directory: project.directory,
       });
 
-      const tempSession: BaseTempSession = {
+      const tempSession: BaseTempSession<QueuedWeComMessage> = {
         conversationId: session.id,
         engineType: session.engineType,
         directory: project.directory,
@@ -879,7 +930,7 @@ export class WeComAdapter extends ChannelAdapter {
       const name = projectName || project.directory.split(/[\\/]/).pop() || project.directory;
       await this.transport!.sendMarkdown(chatId, buildSessionNotification(name, session.engineType, session.id));
 
-      await this.enqueueP2PMessage(chatId, text);
+      await this.enqueueP2PMessage(chatId, text, content ?? [{ type: "text", text }]);
     } catch (err) {
       await this.transport!.sendMarkdown(
         chatId,
@@ -888,11 +939,15 @@ export class WeComAdapter extends ChannelAdapter {
     }
   }
 
-  private async enqueueP2PMessage(chatId: string, text: string): Promise<void> {
+  private async enqueueP2PMessage(
+    chatId: string,
+    text: string,
+    content: MessagePromptContent[],
+  ): Promise<void> {
     const temp = this.sessionMapper.getTempSession(chatId);
     if (!temp) return;
 
-    temp.messageQueue.push(text);
+    temp.messageQueue.push({ text, content });
     if (!temp.processing) {
       await this.processP2PQueue(chatId);
     }
@@ -906,14 +961,14 @@ export class WeComAdapter extends ChannelAdapter {
     }
 
     temp.processing = true;
-    const text = temp.messageQueue.shift()!;
-    await this.sendToEngineP2P(chatId, temp, text);
+    const queued = temp.messageQueue.shift()!;
+    await this.sendToEngineP2P(chatId, temp, queued);
   }
 
   private async sendToEngineP2P(
     chatId: string,
-    tempSession: BaseTempSession,
-    text: string,
+    tempSession: BaseTempSession<QueuedWeComMessage>,
+    queued: QueuedWeComMessage,
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) {
       tempSession.processing = false;
@@ -932,7 +987,7 @@ export class WeComAdapter extends ChannelAdapter {
 
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: tempSession.conversationId,
-      content: [{ type: "text", text }],
+      content: queued.content,
     });
 
     sendPromise
@@ -1007,7 +1062,7 @@ export class WeComAdapter extends ChannelAdapter {
     }
 
     // Regular message → send to engine
-    await this.sendToEngine(`group:${groupChatId}`, binding, text);
+    await this.sendToEngine(`group:${groupChatId}`, binding, [{ type: "text", text }]);
   }
 
   private async handleGroupCommand(
@@ -1154,7 +1209,7 @@ export class WeComAdapter extends ChannelAdapter {
   private async sendToEngine(
     chatTarget: string,
     binding: WeComGroupBinding,
-    text: string,
+    content: MessagePromptContent[],
   ): Promise<void> {
     if (!this.gatewayClient || !this.transport || !this.streamingController) return;
 
@@ -1168,7 +1223,7 @@ export class WeComAdapter extends ChannelAdapter {
 
     const sendPromise = this.gatewayClient.sendMessage({
       sessionId: binding.conversationId,
-      content: [{ type: "text", text }],
+      content,
     });
 
     sendPromise

--- a/electron/main/channels/wecom/wecom-transport.ts
+++ b/electron/main/channels/wecom/wecom-transport.ts
@@ -215,4 +215,40 @@ export class WeComTransport implements MessageTransport {
     // Default to user target
     return { type: "user", id: target };
   }
+
+  // =========================================================================
+  // Image Download
+  // =========================================================================
+
+  /**
+   * Download an image directly from its PicUrl. WeCom serves these via a
+   * public CDN (no token required) but the URL is short-lived.
+   *
+   * Aborts when the body exceeds `maxBytes` to keep memory bounded.
+   */
+  async downloadImageFromUrl(picUrl: string, maxBytes: number): Promise<Buffer | null> {
+    try {
+      const res = await fetch(picUrl);
+      if (!res.ok) {
+        channelLog.error(`[WeCom] Image fetch failed: ${res.status}`);
+        return null;
+      }
+      const contentLength = res.headers.get("content-length");
+      if (contentLength && parseInt(contentLength, 10) > maxBytes) {
+        channelLog.warn(
+          `[WeCom] Image content-length ${contentLength} > ${maxBytes}, skipping`,
+        );
+        return null;
+      }
+      const ab = await res.arrayBuffer();
+      if (ab.byteLength > maxBytes) {
+        channelLog.warn(`[WeCom] Image body ${ab.byteLength} > ${maxBytes}, skipping`);
+        return null;
+      }
+      return Buffer.from(ab);
+    } catch (err) {
+      channelLog.error("[WeCom] Failed to download image:", err);
+      return null;
+    }
+  }
 }

--- a/electron/main/channels/wecom/wecom-types.ts
+++ b/electron/main/channels/wecom/wecom-types.ts
@@ -5,6 +5,7 @@
 // ============================================================================
 
 import type { BaseGroupBinding } from "../base-session-mapper";
+import type { MessagePromptContent } from "../../../../src/types/unified";
 import { GATEWAY_PORT } from "../../../../shared/ports";
 
 // --- WeCom Configuration ---
@@ -39,6 +40,26 @@ export const DEFAULT_WECOM_CONFIG: WeComConfig = {
 /** TTL for temporary P2P sessions (2 hours in ms) */
 export const TEMP_SESSION_TTL_MS = 2 * 60 * 60 * 1000;
 
+// Image limits are sourced from the shared module so frontend, channels, and
+// the gateway-side persistence path stay in sync.
+export {
+  MAX_IMAGE_SIZE_BYTES as MAX_WECOM_IMAGE_BYTES,
+  MAX_IMAGES_PER_MESSAGE as MAX_WECOM_IMAGES_PER_MESSAGE,
+  MAX_TOTAL_IMAGE_BYTES as MAX_WECOM_TOTAL_IMAGE_BYTES,
+} from "../../../../shared/image-limits";
+
+/**
+ * A queued WeCom user message awaiting engine dispatch. Carries already-built
+ * MessagePromptContent so the queue worker can call sendMessage directly
+ * without re-downloading images.
+ */
+export interface QueuedWeComMessage {
+  /** Plain-text representation, used only for logging. */
+  text: string;
+  /** Ordered prompt content (text + image parts) sent to the engine. */
+  content: MessagePromptContent[];
+}
+
 // --- Group Binding ---
 
 /** Binding between a WeCom group chat and a CodeMux session */
@@ -65,6 +86,10 @@ export interface WeComIncomingMessage {
   msgId: string;
   /** Application AgentId */
   agentId: number;
+  /** Image direct URL (only for msgType=image, served by WeCom CDN, no auth) */
+  picUrl?: string;
+  /** Media ID (only for msgType=image; alternative download path) */
+  mediaId?: string;
 }
 
 // --- Command Parser Types ---

--- a/electron/main/channels/weixin-ilink/weixin-ilink-adapter.ts
+++ b/electron/main/channels/weixin-ilink/weixin-ilink-adapter.ts
@@ -431,9 +431,22 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
     }
 
     const text = this.extractText(msg);
-    if (!text) {
+    const hasImage = (msg.item_list ?? []).some((it) => it.type === 2);
+    if (!text && !hasImage) {
       channelLog.verbose(`${LOG_PREFIX} Inbound msg from ${userId} had no text`);
       return;
+    }
+
+    if (hasImage) {
+      // iLink is a private protocol — no public download API for inbound images.
+      // Inform the sender so they switch to the WebUI for screenshots.
+      if (this.transport) {
+        await this.transport.sendText(
+          userId,
+          "⚠️ 微信渠道暂不支持图片转发，请在 WebUI 中上传图片",
+        );
+      }
+      if (!text) return;
     }
 
     channelLog.info(`${LOG_PREFIX} Inbound from ${userId}: ${text.slice(0, 100)}`);
@@ -456,7 +469,8 @@ export class WeixinIlinkAdapter extends ChannelAdapter {
           if (item.text_item?.text) parts.push(item.text_item.text);
           break;
         case 2:
-          parts.push("[Image]");
+          // Image — handled separately with an "unsupported" notice in the
+          // inbound dispatcher; do not insert a placeholder here.
           break;
         case 3:
           if (item.voice_item?.text) parts.push(item.voice_item.text);

--- a/electron/main/engines/claude/index.ts
+++ b/electron/main/engines/claude/index.ts
@@ -49,6 +49,7 @@ import type {
   PermissionReply,
   ToolPart,
   TextPart,
+  FilePart,
   ReasoningPart,
   StepStartPart,
   StepFinishPart,
@@ -199,6 +200,57 @@ function readClaudeSettingsEnv(): Record<string, string> {
 // ============================================================================
 
 const SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * Build user message parts including any image attachments as FileParts so
+ * the frontend can render the same images the user sent (e.g. via channels
+ * like Feishu or the browser UI). Images are emitted as data: URLs.
+ */
+function buildUserMessageParts(
+  messageId: string,
+  sessionId: string,
+  text: string,
+  images: MessagePromptContent[],
+): Array<TextPart | FilePart> {
+  const parts: Array<TextPart | FilePart> = [];
+
+  if (text) {
+    parts.push({
+      id: timeId("pt"),
+      messageId,
+      sessionId,
+      type: "text",
+      text,
+    });
+  }
+
+  for (const c of images) {
+    if (c.type !== "image" || !c.data) continue;
+    const mime = c.mimeType || "image/png";
+    const ext = mime.split("/")[1] || "png";
+    parts.push({
+      id: timeId("pt"),
+      messageId,
+      sessionId,
+      type: "file",
+      mime,
+      filename: `image.${ext}`,
+      url: `data:${mime};base64,${c.data}`,
+    });
+  }
+
+  if (parts.length === 0) {
+    parts.push({
+      id: timeId("pt"),
+      messageId,
+      sessionId,
+      type: "text",
+      text: "",
+    });
+  }
+
+  return parts;
+}
 
 // ============================================================================
 // ClaudeCodeAdapter
@@ -748,7 +800,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
         sessionId,
         role: "user",
         time: { created: Date.now() },
-        parts: [{ type: "text", text: textContent, id: timeId("pt"), messageId: userMsgId, sessionId } as TextPart],
+        parts: buildUserMessageParts(userMsgId, sessionId, textContent, imageContents),
       };
 
       const history = this.messageHistory.get(sessionId) ?? [];
@@ -790,7 +842,7 @@ export class ClaudeCodeAdapter extends EngineAdapter {
       sessionId,
       role: "user",
       time: { created: Date.now() },
-      parts: [{ type: "text", text: textContent, id: timeId("pt"), messageId: userMsgId, sessionId } as TextPart],
+      parts: buildUserMessageParts(userMsgId, sessionId, textContent, imageContents),
     };
 
     // Emit user message

--- a/electron/main/engines/claude/index.ts
+++ b/electron/main/engines/claude/index.ts
@@ -8,6 +8,7 @@
 // ============================================================================
 
 import { timeId } from "../../utils/id-gen";
+import { mimeToFileExtension } from "../../../../shared/image-limits";
 import { CODEMUX_IDENTITY_PROMPT } from "../identity-prompt";
 import {
   unstable_v2_createSession,
@@ -227,7 +228,7 @@ function buildUserMessageParts(
   for (const c of images) {
     if (c.type !== "image" || !c.data) continue;
     const mime = c.mimeType || "image/png";
-    const ext = mime.split("/")[1] || "png";
+    const ext = mimeToFileExtension(mime);
     parts.push({
       id: timeId("pt"),
       messageId,

--- a/electron/main/engines/codex/converters.ts
+++ b/electron/main/engines/codex/converters.ts
@@ -1,6 +1,9 @@
 import { timeId } from "../../utils/id-gen";
 import { inferToolKind, normalizeToolName } from "../../../../src/types/tool-mapping";
+import { mimeToFileExtension } from "../../../../shared/image-limits";
 import type {
+  FilePart,
+  MessagePromptContent,
   NormalizedToolName,
   PermissionDetail,
   PermissionOption,
@@ -660,22 +663,54 @@ export function createUserMessage(
   sessionId: string,
   text: string,
   createdAt = Date.now(),
+  images: MessagePromptContent[] = [],
 ): UnifiedMessage {
   const messageId = timeId("msg");
-  const partId = timeId("part");
+  const parts: Array<TextPart | FilePart> = [];
+  let partIdx = 0;
+  let imageIdx = 0;
+
+  if (text) {
+    parts.push({
+      id: `${messageId}_p${partIdx++}`,
+      messageId,
+      sessionId,
+      type: "text",
+      text,
+    });
+  }
+
+  for (const c of images) {
+    if (c.type !== "image" || !c.data) continue;
+    const mime = c.mimeType || "image/png";
+    const ext = mimeToFileExtension(mime);
+    parts.push({
+      id: `${messageId}_p${partIdx++}`,
+      messageId,
+      sessionId,
+      type: "file",
+      mime,
+      filename: `image-${++imageIdx}.${ext}`,
+      url: `data:${mime};base64,${c.data}`,
+    });
+  }
+
+  if (parts.length === 0) {
+    parts.push({
+      id: `${messageId}_p${partIdx}`,
+      messageId,
+      sessionId,
+      type: "text",
+      text: "",
+    });
+  }
 
   return {
     id: messageId,
     sessionId,
     role: "user",
     time: { created: createdAt, completed: createdAt },
-    parts: [{
-      id: partId,
-      messageId,
-      sessionId,
-      type: "text",
-      text,
-    }],
+    parts,
   };
 }
 

--- a/electron/main/engines/codex/index.ts
+++ b/electron/main/engines/codex/index.ts
@@ -2,6 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs
 import { tmpdir, homedir } from "os";
 import { join } from "path";
 
+import { mimeToFileExtension } from "../../../../shared/image-limits";
 import type {
   AgentMode,
   AuthMethod,
@@ -493,7 +494,7 @@ export class CodexAdapter extends EngineAdapter {
     },
   ): Promise<UnifiedMessage> {
     const prepared = this.buildPromptInput(content);
-    const userMessage = createUserMessage(sessionId, prepared.displayText);
+    const userMessage = createUserMessage(sessionId, prepared.displayText, Date.now(), prepared.images);
     const directory = normalizeDirectory(options?.directory ?? this.sessionDirectories.get(sessionId) ?? this.threads.get(this.sessionToThread.get(sessionId) ?? "")?.directory ?? "");
     if (!directory) {
       this.cleanupTempDirs(prepared.tempDirs);
@@ -1549,7 +1550,7 @@ export class CodexAdapter extends EngineAdapter {
     return this.threadToSession.get(threadId) ?? toEngineSessionId(threadId);
   }
 
-  private buildPromptInput(content: MessagePromptContent[]): { input: CodexTurnInput[]; tempDirs: string[]; displayText: string } {
+  private buildPromptInput(content: MessagePromptContent[]): { input: CodexTurnInput[]; tempDirs: string[]; displayText: string; images: MessagePromptContent[] } {
     const text = content
       .filter((item): item is { type: "text"; text: string } => item.type === "text" && typeof item.text === "string")
       .map((item) => item.text)
@@ -1578,7 +1579,7 @@ export class CodexAdapter extends EngineAdapter {
         let tempDir: string | null = null;
         try {
           tempDir = mkdtempSync(join(tmpdir(), "codemux-codex-img-"));
-          const extension = imageFileExtensionFromMimeType(image.mimeType);
+          const extension = mimeToFileExtension(image.mimeType ?? "image/png");
           const tempPath = join(tempDir, `image.${extension}`);
           writeFileSync(tempPath, decoded);
           tempDirs.push(tempDir);
@@ -1595,7 +1596,8 @@ export class CodexAdapter extends EngineAdapter {
       return {
         input,
         tempDirs,
-        displayText: text || "(image)",
+        displayText: text,
+        images,
       };
     } catch (error) {
       this.cleanupTempDirs(tempDirs);
@@ -2386,22 +2388,4 @@ function toMillis(value: unknown, fallback: number): number {
     if (Number.isFinite(parsed)) return parsed;
   }
   return fallback;
-}
-
-function imageFileExtensionFromMimeType(mimeType?: string): string {
-  if (typeof mimeType !== "string") return "png";
-
-  const normalized = mimeType.trim().toLowerCase().split(";", 1)[0] ?? "";
-  const subtype = normalized.split("/", 2)[1] ?? "";
-
-  switch (subtype) {
-    case "png":
-    case "jpg":
-    case "jpeg":
-    case "webp":
-    case "gif":
-      return subtype;
-    default:
-      return "png";
-  }
 }

--- a/electron/main/engines/copilot/converters.ts
+++ b/electron/main/engines/copilot/converters.ts
@@ -16,6 +16,7 @@ import {
   type NormalizedToolName,
   type ToolPart,
   type TextPart,
+  type FilePart,
   type ReasoningPart,
 } from "../../../../src/types/unified";
 import { homedir } from "os";
@@ -314,21 +315,56 @@ export function convertEventsToMessages(
   return messages;
 }
 
+export interface UserMessageImage {
+  data: string;
+  mimeType: string;
+}
+
 export function createUserMessage(
   sessionId: string,
   text: string,
   timestamp: number,
+  images?: UserMessageImage[],
 ): UnifiedMessage {
   const messageId = timeId("msg");
-  const partId = timeId("part");
+  const parts: Array<TextPart | FilePart> = [];
 
-  const textPart: TextPart = {
-    id: partId,
-    messageId,
-    sessionId,
-    type: "text",
-    text,
-  };
+  if (text) {
+    parts.push({
+      id: timeId("part"),
+      messageId,
+      sessionId,
+      type: "text",
+      text,
+    });
+  }
+
+  if (images && images.length > 0) {
+    for (const img of images) {
+      const mime = img.mimeType || "image/png";
+      const ext = mime.split("/")[1] || "png";
+      parts.push({
+        id: timeId("part"),
+        messageId,
+        sessionId,
+        type: "file",
+        mime,
+        filename: `image.${ext}`,
+        url: `data:${mime};base64,${img.data}`,
+      });
+    }
+  }
+
+  // Always keep at least one part so the bubble renders.
+  if (parts.length === 0) {
+    parts.push({
+      id: timeId("part"),
+      messageId,
+      sessionId,
+      type: "text",
+      text: "",
+    });
+  }
 
   return {
     id: messageId,
@@ -338,7 +374,7 @@ export function createUserMessage(
       created: timestamp,
       completed: timestamp,
     },
-    parts: [textPart],
+    parts,
   };
 }
 

--- a/electron/main/engines/copilot/converters.ts
+++ b/electron/main/engines/copilot/converters.ts
@@ -1,4 +1,5 @@
 import { timeId } from "../../utils/id-gen";
+import { mimeToFileExtension } from "../../../../shared/image-limits";
 import type {
   SessionEvent,
   SessionMetadata,
@@ -342,7 +343,7 @@ export function createUserMessage(
   if (images && images.length > 0) {
     for (const img of images) {
       const mime = img.mimeType || "image/png";
-      const ext = mime.split("/")[1] || "png";
+      const ext = mimeToFileExtension(mime);
       parts.push({
         id: timeId("part"),
         messageId,

--- a/electron/main/engines/copilot/index.ts
+++ b/electron/main/engines/copilot/index.ts
@@ -560,7 +560,15 @@ export class CopilotSdkAdapter extends EngineAdapter {
       // Create user message but DON'T emit yet — defer until handleSessionIdle
       // starts processing this queued turn. Emitting immediately would create
       // a user bubble while the engine is still working on the previous turn.
-      const userMessage = createUserMessage(sessionId, promptText, now);
+      const userMessage = createUserMessage(
+        sessionId,
+        promptText,
+        now,
+        imageContents.map((c) => ({
+          data: (c as { data: string }).data,
+          mimeType: (c as { mimeType?: string }).mimeType ?? "image/png",
+        })),
+      );
       this.appendMessageToHistory(sessionId, userMessage);
 
       // Store for deferred emit
@@ -607,7 +615,15 @@ export class CopilotSdkAdapter extends EngineAdapter {
 
     // --- Normal path: session is idle ---
 
-    const userMessage = createUserMessage(sessionId, promptText, now);
+    const userMessage = createUserMessage(
+      sessionId,
+      promptText,
+      now,
+      imageContents.map((c) => ({
+        data: (c as { data: string }).data,
+        mimeType: (c as { mimeType?: string }).mimeType ?? "image/png",
+      })),
+    );
     this.appendMessageToHistory(sessionId, userMessage);
     this.emit("message.updated", { sessionId, message: userMessage });
 

--- a/electron/main/gateway/engine-manager.ts
+++ b/electron/main/gateway/engine-manager.ts
@@ -627,9 +627,14 @@ export class EngineManager extends EventEmitter {
       const now = Date.now();
       const msgId = timeId("msg");
 
-      // Build parts from prompt content (text + image placeholders)
-      const parts: Array<TextPart> = [];
+      // Build parts from prompt content. Images are persisted inline as
+      // data: URLs inside a FilePart so the webui can render them after
+      // session reload. Per-image size is already bounded upstream
+      // (frontend & Feishu both cap individual images at 3MB), so the
+      // resulting JSON growth is acceptable.
+      const parts: Array<TextPart | FilePart> = [];
       let partIdx = 0;
+      let imageIdx = 0;
       for (const c of content) {
         if (c.type === "text" && c.text) {
           parts.push({
@@ -640,14 +645,16 @@ export class EngineManager extends EventEmitter {
             text: c.text,
           });
         } else if (c.type === "image" && c.data) {
-          // Store image as a text placeholder — base64 data is not persisted
-          // to avoid bloating conversation files
+          const mime = c.mimeType ?? "image/png";
+          const ext = mime.split("/")[1]?.split(/[;+]/)[0] || "png";
           parts.push({
-            type: "text" as const,
+            type: "file" as const,
             id: `${msgId}_p${partIdx++}`,
             messageId: msgId,
             sessionId: conversationId,
-            text: `[Image: ${c.mimeType ?? "image"}]`,
+            mime,
+            filename: `image-${++imageIdx}.${ext}`,
+            url: `data:${mime};base64,${c.data}`,
           });
         }
       }

--- a/electron/main/gateway/engine-manager.ts
+++ b/electron/main/gateway/engine-manager.ts
@@ -9,6 +9,7 @@ import { getDefaultWorkspacePath } from "../services/default-workspace";
 import { engineManagerLog, getDefaultEngineFromSettings } from "../services/logger";
 import { timeId } from "../utils/id-gen";
 import { isDefaultTitle, isPromptFallbackTitle } from "../../../src/lib/session-utils";
+import { mimeToFileExtension } from "../../../shared/image-limits";
 import type {
   EngineType,
   EngineInfo,
@@ -646,7 +647,7 @@ export class EngineManager extends EventEmitter {
           });
         } else if (c.type === "image" && c.data) {
           const mime = c.mimeType ?? "image/png";
-          const ext = mime.split("/")[1]?.split(/[;+]/)[0] || "png";
+          const ext = mimeToFileExtension(mime);
           parts.push({
             type: "file" as const,
             id: `${msgId}_p${partIdx++}`,

--- a/shared/image-limits.ts
+++ b/shared/image-limits.ts
@@ -72,3 +72,17 @@ export function validateImageAddition(
 export function isAcceptedImageMime(mime: string): mime is AcceptedImageMimeType {
   return (ACCEPTED_IMAGE_MIME_TYPES as readonly string[]).includes(mime);
 }
+
+/**
+ * Derive a filename extension from an image MIME type string.
+ *
+ * Strips compound suffixes (`image/svg+xml` → `svg`) and any media-type
+ * parameters (`image/png; q=0.9` → `png`). Falls back to `"png"` when the
+ * subtype is missing or empty so callers always have a renderable name.
+ *
+ * Single source of truth for the engine adapters and the gateway-side
+ * persistence path that materialize image attachments as `FilePart`s.
+ */
+export function mimeToFileExtension(mime: string): string {
+  return mime.split("/")[1]?.split(/[;+]/)[0] || "png";
+}

--- a/shared/image-limits.ts
+++ b/shared/image-limits.ts
@@ -78,11 +78,14 @@ export function isAcceptedImageMime(mime: string): mime is AcceptedImageMimeType
  *
  * Strips compound suffixes (`image/svg+xml` → `svg`) and any media-type
  * parameters (`image/png; q=0.9` → `png`). Falls back to `"png"` when the
- * subtype is missing or empty so callers always have a renderable name.
+ * subtype is missing, empty, or contains characters outside the safe set
+ * `[A-Za-z0-9]` so callers can safely join the result into a filesystem
+ * path without risking path traversal from a malformed MIME string.
  *
  * Single source of truth for the engine adapters and the gateway-side
  * persistence path that materialize image attachments as `FilePart`s.
  */
 export function mimeToFileExtension(mime: string): string {
-  return mime.split("/")[1]?.split(/[;+]/)[0] || "png";
+  const raw = mime.split("/")[1]?.split(/[;+]/)[0]?.trim().toLowerCase() ?? "";
+  return /^[a-z0-9]+$/.test(raw) ? raw : "png";
 }

--- a/shared/image-limits.ts
+++ b/shared/image-limits.ts
@@ -1,0 +1,74 @@
+// ============================================================================
+// Shared image attachment limits (frontend + channel adapters)
+//
+// Why these numbers:
+//   - Gateway WS payload cap is 20 MB (electron/main/gateway/ws-server.ts).
+//   - base64 inflates raw bytes by ~33%.
+//   - JSON wrapping + text content + safety margin reserves ~4 MB.
+//   - That leaves ~12 MB raw bytes per message for image payload.
+//
+// Single source of truth so the frontend, all channel adapters, and the
+// gateway-side persistence path can stay consistent.
+// ============================================================================
+
+/** Max raw bytes for a single image attachment. */
+export const MAX_IMAGE_SIZE_BYTES = 3 * 1024 * 1024;
+
+/** Max image attachments per outgoing message. */
+export const MAX_IMAGES_PER_MESSAGE = 4;
+
+/** Max total raw bytes across all images in a single outgoing message. */
+export const MAX_TOTAL_IMAGE_BYTES = 12 * 1024 * 1024;
+
+/** Whitelisted MIME types. */
+export const ACCEPTED_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export type AcceptedImageMimeType = (typeof ACCEPTED_IMAGE_MIME_TYPES)[number];
+
+export interface ImageCandidate {
+  /** Raw byte size before base64 encoding. */
+  size: number;
+  /** MIME type. */
+  mimeType: string;
+}
+
+export type ImageRejectionReason = "mime" | "size" | "count" | "total";
+
+export interface ImageValidationResult {
+  ok: boolean;
+  reason?: ImageRejectionReason;
+}
+
+/**
+ * Validate whether `candidate` may be added to the existing set of images for
+ * the same outgoing message. Pure function — safe to call from both renderer
+ * and main processes.
+ */
+export function validateImageAddition(
+  existing: readonly ImageCandidate[],
+  candidate: ImageCandidate,
+): ImageValidationResult {
+  if (!isAcceptedImageMime(candidate.mimeType)) {
+    return { ok: false, reason: "mime" };
+  }
+  if (candidate.size > MAX_IMAGE_SIZE_BYTES) {
+    return { ok: false, reason: "size" };
+  }
+  if (existing.length >= MAX_IMAGES_PER_MESSAGE) {
+    return { ok: false, reason: "count" };
+  }
+  const totalAfter = existing.reduce((sum, img) => sum + img.size, 0) + candidate.size;
+  if (totalAfter > MAX_TOTAL_IMAGE_BYTES) {
+    return { ok: false, reason: "total" };
+  }
+  return { ok: true };
+}
+
+export function isAcceptedImageMime(mime: string): mime is AcceptedImageMimeType {
+  return (ACCEPTED_IMAGE_MIME_TYPES as readonly string[]).includes(mime);
+}

--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -3,10 +3,12 @@ import { IconArrowUp } from "./icons";
 import { useI18n } from "../lib/i18n";
 import { notify } from "../lib/notifications";
 import type { AgentMode, ImageAttachment, EngineCommand } from "../types/unified";
-
-const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/png", "image/gif", "image/webp"];
-const MAX_IMAGE_SIZE = 3 * 1024 * 1024; // 3MB per image — stays within WS payload limits after base64/JSON overhead
-const MAX_IMAGES = 4;
+import {
+  ACCEPTED_IMAGE_MIME_TYPES,
+  MAX_IMAGES_PER_MESSAGE,
+  MAX_IMAGE_SIZE_BYTES,
+  validateImageAddition,
+} from "../../shared/image-limits";
 
 /**
  * Resolve a display name for a mode.
@@ -250,16 +252,20 @@ export function PromptInput(props: PromptInputProps) {
   onCleanup(() => document.removeEventListener("mousedown", handleClickOutside));
 
   const addImageFromFile = (file: File) => {
-    if (!ACCEPTED_IMAGE_TYPES.includes(file.type)) {
-      notify(t().prompt.imageUnsupportedType, "warning", 3000);
-      return;
-    }
-    if (file.size > MAX_IMAGE_SIZE) {
-      notify(t().prompt.imageTooLarge, "warning", 3000);
-      return;
-    }
-    if (images().length >= MAX_IMAGES) {
-      notify(t().prompt.imageLimitReached, "warning", 3000);
+    const validation = validateImageAddition(
+      images().map((img) => ({ size: img.size, mimeType: img.mimeType })),
+      { size: file.size, mimeType: file.type },
+    );
+    if (!validation.ok) {
+      const key =
+        validation.reason === "mime"
+          ? "imageUnsupportedType"
+          : validation.reason === "size"
+            ? "imageTooLarge"
+            : validation.reason === "count"
+              ? "imageLimitReached"
+              : "imageTotalTooLarge";
+      notify(t().prompt[key], "warning", 3000);
       return;
     }
 
@@ -604,7 +610,7 @@ export function PromptInput(props: PromptInputProps) {
                   <Show when={props.imageAttachmentEnabled}>
                     <button
                       onClick={() => fileInputRef?.click()}
-                      disabled={props.disabled || images().length >= MAX_IMAGES}
+                      disabled={props.disabled || images().length >= MAX_IMAGES_PER_MESSAGE}
                       class="p-2 rounded-xl text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors disabled:opacity-30"
                       aria-label={t().prompt.attachImage}
                       title={t().prompt.attachImage}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -265,6 +265,7 @@ export interface LocaleDict {
     imageTooLarge: string;
     imageUnsupportedType: string;
     imageLimitReached: string;
+    imageTotalTooLarge: string;
     removeImage: string;
     /** Slash command autocomplete: no matching commands */
     noCommandsFound: string;
@@ -970,6 +971,7 @@ export const en: LocaleDict = {
     imageTooLarge: "Image too large (max 3MB)",
     imageUnsupportedType: "Unsupported image type",
     imageLimitReached: "Maximum 4 images per message",
+    imageTotalTooLarge: "Total image size too large (max 12MB)",
     removeImage: "Remove image",
     noCommandsFound: "No commands found",
     reasoningEffortLow: "Low",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -264,6 +264,7 @@ export const ru: LocaleDict = {
     imageTooLarge: "Изображение слишком большое (максимум 3 МБ)",
     imageUnsupportedType: "Неподдерживаемый формат изображения",
     imageLimitReached: "Максимум 4 изображения на сообщение",
+    imageTotalTooLarge: "Общий размер изображений слишком велик (максимум 12 МБ)",
     removeImage: "Удалить изображение",
     noCommandsFound: "Команды не найдены",
     reasoningEffortLow: "Низкий",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -263,6 +263,7 @@ export const zh: LocaleDict = {
     imageTooLarge: "图片过大（最大 3MB）",
     imageUnsupportedType: "不支持的图片格式",
     imageLimitReached: "每条消息最多 4 张图片",
+    imageTotalTooLarge: "图片总大小过大（最大 12MB）",
     removeImage: "移除图片",
     noCommandsFound: "未找到匹配的命令",
     reasoningEffortLow: "低",

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -2389,13 +2389,39 @@ export default function Chat() {
       parts: [],
     };
 
-    const tempPart: UnifiedPart = {
-      id: tempPartId,
-      messageId: tempMessageId,
-      sessionId: sessionId,
-      type: "text",
-      text,
-    } as UnifiedPart;
+    const tempParts: UnifiedPart[] = [];
+    if (text) {
+      tempParts.push({
+        id: tempPartId,
+        messageId: tempMessageId,
+        sessionId: sessionId,
+        type: "text",
+        text,
+      } as UnifiedPart);
+    }
+    if (images && images.length > 0) {
+      for (let i = 0; i < images.length; i++) {
+        const img = images[i];
+        tempParts.push({
+          id: `${tempPartId}-img-${i}`,
+          messageId: tempMessageId,
+          sessionId: sessionId,
+          type: "file",
+          mime: img.mimeType,
+          filename: img.name,
+          url: `data:${img.mimeType};base64,${img.data}`,
+        } as UnifiedPart);
+      }
+    }
+    if (tempParts.length === 0) {
+      tempParts.push({
+        id: tempPartId,
+        messageId: tempMessageId,
+        sessionId: sessionId,
+        type: "text",
+        text: "",
+      } as UnifiedPart);
+    }
 
     const messages = messageStore.message[sessionId] || [];
 
@@ -2408,7 +2434,7 @@ export default function Chat() {
       setMessageStore("message", sessionId, (draft) => [...draft, tempMessageInfo]);
     }
 
-    setMessageStore("part", tempMessageId, [tempPart]);
+    setMessageStore("part", tempMessageId, tempParts);
     setUserScrolledUp(false);
     setTimeout(() => scrollToBottom(), 0);
 

--- a/tests/unit/electron/channels/dingtalk/dingtalk-adapter.test.ts
+++ b/tests/unit/electron/channels/dingtalk/dingtalk-adapter.test.ts
@@ -220,7 +220,7 @@ describe("DingTalkAdapter", () => {
         senderNick: "alice",
         conversationId: "c1",
       });
-      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "u1", "hi");
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.sessionMapper.getP2PChat("c1")).toBeDefined();
     });
 
@@ -237,7 +237,7 @@ describe("DingTalkAdapter", () => {
         conversationId: "c1",
         chatId: "g1",
       });
-      expect(a.handleGroupMessage).toHaveBeenCalledWith("g1", "hi");
+      expect(a.handleGroupMessage).toHaveBeenCalledWith("g1", "hi", [{ type: "text", text: "hi" }]);
     });
   });
 
@@ -275,7 +275,7 @@ describe("DingTalkAdapter", () => {
     it("falls back to showProjectList when nothing selected", async () => {
       const a = makeP2P();
       a.showProjectList = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.showProjectList).toHaveBeenCalledWith("c1");
     });
 
@@ -292,8 +292,8 @@ describe("DingTalkAdapter", () => {
         processing: true,
       });
       a.enqueueP2PMessage = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("creates temp session if last project selected and no temp exists", async () => {
@@ -305,7 +305,7 @@ describe("DingTalkAdapter", () => {
         projectId: "p",
       });
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
   });
@@ -467,7 +467,7 @@ describe("DingTalkAdapter", () => {
         "hi",
       );
       expect(a.sessionMapper.getTempSession("c1")?.conversationId).toBe("sess-2");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("createTempSessionAndSend reports error on createSession failure", async () => {

--- a/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
@@ -347,9 +347,20 @@ describe("FeishuAdapter", () => {
       };
     }
 
-    it("ignores non-text messages", async () => {
+    it("ignores non-text messages without content", async () => {
       const a = make();
-      await a.handleFeishuMessage(ev({ message: { message_type: "image" } }));
+      // image type with no image_key → parser yields empty parts → routing skipped
+      await a.handleFeishuMessage(
+        ev({ message: { message_type: "image", content: JSON.stringify({}) } }),
+      );
+      expect(a.handleP2PMessage).not.toHaveBeenCalled();
+    });
+
+    it("ignores unsupported message types", async () => {
+      const a = make();
+      await a.handleFeishuMessage(
+        ev({ message: { message_type: "sticker", content: JSON.stringify({}) } }),
+      );
       expect(a.handleP2PMessage).not.toHaveBeenCalled();
     });
 
@@ -363,7 +374,9 @@ describe("FeishuAdapter", () => {
     it("falls back to raw content when JSON.parse fails", async () => {
       const a = make();
       await a.handleFeishuMessage(ev({ message: { content: "raw plain" } }));
-      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "raw plain");
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "raw plain", "m1", [
+        { type: "text", text: "raw plain" },
+      ]);
     });
 
     it("strips @_user_N mentions and skips empty text", async () => {
@@ -377,7 +390,9 @@ describe("FeishuAdapter", () => {
     it("routes p2p chat to handleP2PMessage and registers openId mapping", async () => {
       const a = make();
       await a.handleFeishuMessage(ev());
-      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "hi", "m1", [
+        { type: "text", text: "hi" },
+      ]);
       expect(a.sessionMapper.getChatIdByOpenId("u1")).toBe("c1");
     });
 
@@ -388,6 +403,21 @@ describe("FeishuAdapter", () => {
       expect(a.sessionMapper.getPendingSelection("c1")?.type).toBe("project");
     });
 
+    it("routes image messages to handleP2PMessage with image-key parts", async () => {
+      const a = make();
+      await a.handleFeishuMessage(
+        ev({
+          message: {
+            message_type: "image",
+            content: JSON.stringify({ image_key: "img_abc" }),
+          },
+        }),
+      );
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "", "m1", [
+        { type: "image-key", imageKey: "img_abc" },
+      ]);
+    });
+
     it("routes group chats to handleGroupMessage", async () => {
       const a = make();
       await a.handleFeishuMessage(
@@ -395,7 +425,9 @@ describe("FeishuAdapter", () => {
           message: { chat_id: "g1", chat_type: "group" },
         }),
       );
-      expect(a.handleGroupMessage).toHaveBeenCalledWith("g1", "hi");
+      expect(a.handleGroupMessage).toHaveBeenCalledWith("g1", "hi", "m1", [
+        { type: "text", text: "hi" },
+      ]);
     });
   });
 
@@ -417,7 +449,7 @@ describe("FeishuAdapter", () => {
       a.sessionMapper.getOrCreateP2PChat("c1", "u1");
       a.sessionMapper.setPendingSelection("c1", { type: "project", projects: [] });
       a.handleP2PCommand = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "/help");
+      await a.handleP2PMessage("c1", "/help", "m1", [{ type: "text", text: "/help" }]);
       expect(a.handleP2PCommand).toHaveBeenCalled();
       expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
     });
@@ -425,7 +457,7 @@ describe("FeishuAdapter", () => {
     it("freeform answer routes to pending question", async () => {
       const a = makeP2P();
       a.sessionMapper.setPendingQuestion("c1", { questionId: "q-1", sessionId: "s1" });
-      await a.handleP2PMessage("c1", "my answer");
+      await a.handleP2PMessage("c1", "my answer", "m1", [{ type: "text", text: "my answer" }]);
       expect(a.gatewayClient.replyQuestion).toHaveBeenCalledWith({
         questionId: "q-1",
         answers: [["my answer"]],
@@ -435,7 +467,7 @@ describe("FeishuAdapter", () => {
     it("falls back to showProjectList when nothing selected and no default project", async () => {
       const a = makeP2P();
       a.showProjectList = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "hi");
+      await a.handleP2PMessage("c1", "hi", "m1", [{ type: "text", text: "hi" }]);
       expect(a.showProjectList).toHaveBeenCalledWith("c1");
     });
 
@@ -445,7 +477,7 @@ describe("FeishuAdapter", () => {
         { id: "def", directory: "/def", engineType: "claude", isDefault: true },
       ]);
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "hi");
+      await a.handleP2PMessage("c1", "hi", "m1", [{ type: "text", text: "hi" }]);
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
 
@@ -457,8 +489,11 @@ describe("FeishuAdapter", () => {
         lastActiveAt: Date.now(), messageQueue: [], processing: true,
       });
       a.enqueueP2PMessage = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "hi");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      await a.handleP2PMessage("c1", "hi", "m1", [{ type: "text", text: "hi" }]);
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", {
+        text: "hi",
+        content: [{ type: "text", text: "hi" }],
+      });
     });
 
     it("creates temp session if last project selected and no temp exists", async () => {
@@ -468,7 +503,7 @@ describe("FeishuAdapter", () => {
         directory: "/d", engineType: "claude", projectId: "p",
       });
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "hi");
+      await a.handleP2PMessage("c1", "hi", "m1", [{ type: "text", text: "hi" }]);
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
 
@@ -485,7 +520,7 @@ describe("FeishuAdapter", () => {
       });
       a.cleanupExpiredTempSession = vi.fn(async () => undefined);
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "hi");
+      await a.handleP2PMessage("c1", "hi", "m1", [{ type: "text", text: "hi" }]);
       expect(a.cleanupExpiredTempSession).toHaveBeenCalledWith("c1");
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
@@ -876,7 +911,7 @@ describe("FeishuAdapter", () => {
     it("handleGroupMessage warns when no binding", async () => {
       const a = new FeishuAdapter() as any;
       a.transport = { sendText: vi.fn(async () => ""), sendMarkdown: vi.fn(async () => "") };
-      await a.handleGroupMessage("g1", "hi");
+      await a.handleGroupMessage("g1", "hi", "m1", [{ type: "text", text: "hi" }]);
       expect(a.transport.sendMarkdown.mock.calls[0][1]).toContain("未绑定");
     });
 
@@ -885,7 +920,7 @@ describe("FeishuAdapter", () => {
       a.transport = { sendText: vi.fn(async () => ""), sendMarkdown: vi.fn(async () => "") };
       a.sessionMapper.createGroupBinding(makeBinding());
       a.handleGroupCommand = vi.fn(async () => undefined);
-      await a.handleGroupMessage("g1", "/help");
+      await a.handleGroupMessage("g1", "/help", "m1", [{ type: "text", text: "/help" }]);
       expect(a.handleGroupCommand).toHaveBeenCalled();
     });
 
@@ -895,7 +930,7 @@ describe("FeishuAdapter", () => {
       a.gatewayClient = { replyQuestion: vi.fn(async () => undefined) };
       a.sessionMapper.createGroupBinding(makeBinding());
       a.sessionMapper.setPendingQuestion("g1", { questionId: "q-1", sessionId: "s1" });
-      await a.handleGroupMessage("g1", "an answer");
+      await a.handleGroupMessage("g1", "an answer", "m1", [{ type: "text", text: "an answer" }]);
       expect(a.gatewayClient.replyQuestion).toHaveBeenCalledWith({
         questionId: "q-1",
         answers: [["an answer"]],
@@ -907,7 +942,7 @@ describe("FeishuAdapter", () => {
       a.transport = { sendText: vi.fn(async () => ""), sendMarkdown: vi.fn(async () => "") };
       a.sessionMapper.createGroupBinding(makeBinding());
       a.sendToEngine = vi.fn(async () => undefined);
-      await a.handleGroupMessage("g1", "hello");
+      await a.handleGroupMessage("g1", "hello", "m1", [{ type: "text", text: "hello" }]);
       expect(a.sendToEngine).toHaveBeenCalled();
     });
 
@@ -1387,6 +1422,153 @@ describe("FeishuAdapter", () => {
       await a.showProjectListFromMenu("u1", "c1", "c1", "chat_id");
       expect(a.transport.sendMessageTo.mock.calls[0][2]).toBe("interactive");
       expect(a.sessionMapper.getPendingSelection("c1")?.type).toBe("project");
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  describe("image attachment pipeline", () => {
+    const PNG_HEADER = Buffer.from([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0xde, 0xad, 0xbe, 0xef,
+    ]);
+    const JPEG_HEADER = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0xaa]);
+
+    it("downloadImagesForParts downloads each image and detects MIME", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async (_m: string, key: string) =>
+          key === "k1" ? PNG_HEADER : JPEG_HEADER,
+        ),
+      };
+      const map = await a.downloadImagesForParts("msg-1", [
+        { type: "image-key", imageKey: "k1" },
+        { type: "image-key", imageKey: "k2" },
+      ]);
+      expect(map.get("k1")).toEqual({
+        data: PNG_HEADER.toString("base64"),
+        mimeType: "image/png",
+      });
+      expect(map.get("k2")).toEqual({
+        data: JPEG_HEADER.toString("base64"),
+        mimeType: "image/jpeg",
+      });
+    });
+
+    it("downloadImagesForParts deduplicates by image key", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => PNG_HEADER),
+      };
+      await a.downloadImagesForParts("msg-1", [
+        { type: "image-key", imageKey: "same" },
+        { type: "image-key", imageKey: "same" },
+        { type: "image-key", imageKey: "same" },
+      ]);
+      expect(a.transport.downloadMessageImage).toHaveBeenCalledTimes(1);
+    });
+
+    it("downloadImagesForParts caps at MAX_FEISHU_IMAGES_PER_MESSAGE (4)", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => PNG_HEADER),
+      };
+      const parts = Array.from({ length: 6 }, (_, i) => ({
+        type: "image-key" as const,
+        imageKey: `k${i}`,
+      }));
+      const map = await a.downloadImagesForParts("msg-1", parts);
+      expect(map.size).toBe(4);
+      expect(a.transport.downloadMessageImage).toHaveBeenCalledTimes(4);
+    });
+
+    it("downloadImagesForParts skips images with unknown MIME", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => Buffer.from([0x00, 0x01, 0x02, 0x03])),
+      };
+      const map = await a.downloadImagesForParts("msg-1", [
+        { type: "image-key", imageKey: "k1" },
+      ]);
+      expect(map.size).toBe(0);
+    });
+
+    it("downloadImagesForParts skips images whose download returned null", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => null),
+      };
+      const map = await a.downloadImagesForParts("msg-1", [
+        { type: "image-key", imageKey: "k1" },
+      ]);
+      expect(map.size).toBe(0);
+    });
+
+    it("downloadImagesForParts ignores non-image-key parts", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => PNG_HEADER),
+      };
+      const map = await a.downloadImagesForParts("msg-1", [
+        { type: "text", text: "hi" },
+      ]);
+      expect(map.size).toBe(0);
+      expect(a.transport.downloadMessageImage).not.toHaveBeenCalled();
+    });
+
+    it("buildEngineContent fast-path returns text-only when no image keys", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = { downloadMessageImage: vi.fn() };
+      const content = await a.buildEngineContent("msg", "hello", [
+        { type: "text", text: "hello" },
+      ]);
+      expect(content).toEqual([{ type: "text", text: "hello" }]);
+      expect(a.transport.downloadMessageImage).not.toHaveBeenCalled();
+    });
+
+    it("buildEngineContent returns empty when text empty and no image parts", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = { downloadMessageImage: vi.fn() };
+      const content = await a.buildEngineContent("msg", "", []);
+      expect(content).toEqual([]);
+    });
+
+    it("buildEngineContent preserves order text→image→text", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => PNG_HEADER),
+      };
+      const content = await a.buildEngineContent("msg", "before\nafter", [
+        { type: "text", text: "before" },
+        { type: "image-key", imageKey: "k1" },
+        { type: "text", text: "after" },
+      ]);
+      expect(content).toEqual([
+        { type: "text", text: "before" },
+        { type: "image", data: PNG_HEADER.toString("base64"), mimeType: "image/png" },
+        { type: "text", text: "after" },
+      ]);
+    });
+
+    it("buildEngineContent falls back to text-only when every image download fails", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => null),
+      };
+      const content = await a.buildEngineContent("msg", "hi", [
+        { type: "text", text: "hi" },
+        { type: "image-key", imageKey: "k1" },
+      ]);
+      expect(content).toEqual([{ type: "text", text: "hi" }]);
+    });
+
+    it("buildEngineContent returns empty when image-only message has no successful downloads", async () => {
+      const a = new FeishuAdapter() as any;
+      a.transport = {
+        downloadMessageImage: vi.fn(async () => null),
+      };
+      const content = await a.buildEngineContent("msg", "", [
+        { type: "image-key", imageKey: "k1" },
+      ]);
+      expect(content).toEqual([]);
     });
   });
 });

--- a/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-adapter.test.ts
@@ -524,6 +524,46 @@ describe("FeishuAdapter", () => {
       expect(a.cleanupExpiredTempSession).toHaveBeenCalledWith("c1");
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
+
+    it("clears stale pending selection when an image-only message arrives", async () => {
+      const a = makeP2P();
+      a.sessionMapper.getOrCreateP2PChat("c1", "u1");
+      a.sessionMapper.setPendingSelection("c1", { type: "project", projects: [] });
+      a.sessionMapper.setP2PLastProject("c1", {
+        directory: "/d", engineType: "claude", projectId: "p",
+      });
+      a.createTempSessionAndSend = vi.fn(async () => undefined);
+      a.downloadImagesForParts = vi.fn(async () =>
+        new Map([["k1", { data: "AAA", mimeType: "image/png" }]]),
+      );
+      a.handlePendingSelection = vi.fn(async () => true);
+      await a.handleP2PMessage("c1", "", "m1", [{ type: "image-key", imageKey: "k1" }]);
+      expect(a.handlePendingSelection).not.toHaveBeenCalled();
+      expect(a.sessionMapper.getPendingSelection("c1")).toBeUndefined();
+      expect(a.createTempSessionAndSend).toHaveBeenCalled();
+    });
+
+    it("notifies the user when an image-only message has zero successful downloads", async () => {
+      const a = makeP2P();
+      a.sessionMapper.getOrCreateP2PChat("c1", "u1");
+      a.downloadImagesForParts = vi.fn(async () => new Map());
+      a.createTempSessionAndSend = vi.fn(async () => undefined);
+      a.enqueueP2PMessage = vi.fn(async () => undefined);
+      await a.handleP2PMessage("c1", "", "m1", [{ type: "image-key", imageKey: "k1" }]);
+      expect(a.transport.sendText).toHaveBeenCalledWith(
+        "c1",
+        expect.stringContaining("图片处理失败"),
+      );
+      expect(a.createTempSessionAndSend).not.toHaveBeenCalled();
+      expect(a.enqueueP2PMessage).not.toHaveBeenCalled();
+    });
+
+    it("does NOT notify when the empty-content drop is due to an empty text-only message", async () => {
+      const a = makeP2P();
+      a.sessionMapper.getOrCreateP2PChat("c1", "u1");
+      await a.handleP2PMessage("c1", "", "m1", []);
+      expect(a.transport.sendText).not.toHaveBeenCalled();
+    });
   });
 
   // ---------------------------------------------------------------------

--- a/tests/unit/electron/channels/feishu/feishu-content-parser.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-content-parser.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPromptContent,
+  detectImageMime,
+  parseFeishuMessageContent,
+  stripFeishuMentions,
+  type ParsedContentPart,
+} from "../../../../../electron/main/channels/feishu/feishu-content-parser";
+
+describe("stripFeishuMentions", () => {
+  it.each([
+    ["@_user_1 hello", " hello"],
+    ["hi @_user_42 there @_user_3", "hi  there "],
+    ["plain text", "plain text"],
+    ["@_user_", "@_user_"],
+    ["@_user_12abc", "abc"],
+  ])("strips %j → %j", (input, expected) => {
+    expect(stripFeishuMentions(input)).toBe(expected);
+  });
+});
+
+describe("parseFeishuMessageContent", () => {
+  describe("text message", () => {
+    it("extracts text from JSON content", () => {
+      const result = parseFeishuMessageContent("text", JSON.stringify({ text: "hello" }));
+      expect(result).toEqual({
+        text: "hello",
+        parts: [{ type: "text", text: "hello" }],
+      });
+    });
+
+    it("strips mentions and trims whitespace", () => {
+      const result = parseFeishuMessageContent(
+        "text",
+        JSON.stringify({ text: "  @_user_1 hello @_user_2  " }),
+      );
+      expect(result.text).toBe("hello");
+      expect(result.parts).toEqual([{ type: "text", text: "hello" }]);
+    });
+
+    it("returns empty when text reduces to nothing after mention strip", () => {
+      const result = parseFeishuMessageContent(
+        "text",
+        JSON.stringify({ text: "@_user_1 @_user_2   " }),
+      );
+      expect(result).toEqual({ text: "", parts: [] });
+    });
+
+    it("falls back to raw content when JSON.parse fails", () => {
+      const result = parseFeishuMessageContent("text", "raw plain string");
+      expect(result.text).toBe("raw plain string");
+      expect(result.parts).toEqual([{ type: "text", text: "raw plain string" }]);
+    });
+
+    it("returns empty when text field missing or not a string", () => {
+      expect(parseFeishuMessageContent("text", JSON.stringify({}))).toEqual({
+        text: "",
+        parts: [],
+      });
+      expect(parseFeishuMessageContent("text", JSON.stringify({ text: 123 }))).toEqual({
+        text: "",
+        parts: [],
+      });
+    });
+  });
+
+  describe("image message", () => {
+    it("extracts image_key", () => {
+      const result = parseFeishuMessageContent(
+        "image",
+        JSON.stringify({ image_key: "img_abc" }),
+      );
+      expect(result).toEqual({
+        text: "",
+        parts: [{ type: "image-key", imageKey: "img_abc" }],
+      });
+    });
+
+    it("returns empty when image_key missing", () => {
+      expect(parseFeishuMessageContent("image", JSON.stringify({}))).toEqual({
+        text: "",
+        parts: [],
+      });
+    });
+
+    it("returns empty on malformed JSON", () => {
+      expect(parseFeishuMessageContent("image", "not json")).toEqual({
+        text: "",
+        parts: [],
+      });
+    });
+
+    it("ignores non-string image_key values", () => {
+      expect(
+        parseFeishuMessageContent("image", JSON.stringify({ image_key: 42 })),
+      ).toEqual({ text: "", parts: [] });
+    });
+  });
+
+  describe("post message", () => {
+    it("includes title as first text part", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          title: "My Post",
+          content: [[{ tag: "text", text: "body" }]],
+        }),
+      );
+      expect(result.parts).toEqual([
+        { type: "text", text: "My Post" },
+        { type: "text", text: "body" },
+      ]);
+      expect(result.text).toBe("My Post\nbody");
+    });
+
+    it("preserves order of text and images within a row", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[
+            { tag: "text", text: "before " },
+            { tag: "img", image_key: "img_1" },
+            { tag: "text", text: " after" },
+          ]],
+        }),
+      );
+      expect(result.parts).toEqual([
+        { type: "text", text: "before" },
+        { type: "image-key", imageKey: "img_1" },
+        { type: "text", text: "after" },
+      ]);
+    });
+
+    it("handles multiple rows preserving order", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [
+            [{ tag: "text", text: "row1" }],
+            [{ tag: "img", image_key: "img_a" }],
+            [{ tag: "text", text: "row3" }],
+          ],
+        }),
+      );
+      expect(result.parts).toEqual([
+        { type: "text", text: "row1" },
+        { type: "image-key", imageKey: "img_a" },
+        { type: "text", text: "row3" },
+      ]);
+    });
+
+    it("renders links as markdown when href present", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[{ tag: "a", text: "GitHub", href: "https://github.com" }]],
+        }),
+      );
+      expect(result.parts).toEqual([
+        { type: "text", text: "[GitHub](https://github.com)" },
+      ]);
+    });
+
+    it("renders link without href as plain text", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[{ tag: "a", text: "GitHub" }]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "GitHub" }]);
+    });
+
+    it("renders at mentions with @user_name", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[
+            { tag: "text", text: "hi " },
+            { tag: "at", user_name: "alice" },
+          ]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "hi @alice" }]);
+    });
+
+    it("renders code_inline with backticks", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[{ tag: "code_inline", text: "npm run dev" }]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "`npm run dev`" }]);
+    });
+
+    it("ignores unknown tags", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[
+            { tag: "text", text: "keep " },
+            { tag: "media", url: "x" },
+            { tag: "text", text: "this" },
+          ]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "keep this" }]);
+    });
+
+    it("skips img element without image_key", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[
+            { tag: "text", text: "no img" },
+            { tag: "img" },
+          ]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "no img" }]);
+    });
+
+    it("returns empty on malformed JSON", () => {
+      expect(parseFeishuMessageContent("post", "garbage")).toEqual({
+        text: "",
+        parts: [],
+      });
+    });
+
+    it("returns empty when content array missing", () => {
+      expect(
+        parseFeishuMessageContent("post", JSON.stringify({ title: "" })),
+      ).toEqual({ text: "", parts: [] });
+    });
+
+    it("skips rows that are not arrays", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: ["bad row", [{ tag: "text", text: "good" }]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "good" }]);
+    });
+
+    it("strips @_user_N mentions from post text parts", () => {
+      const result = parseFeishuMessageContent(
+        "post",
+        JSON.stringify({
+          content: [[{ tag: "text", text: "@_user_1 hello" }]],
+        }),
+      );
+      expect(result.parts).toEqual([{ type: "text", text: "hello" }]);
+    });
+  });
+
+  describe("unsupported message types", () => {
+    it.each(["audio", "video", "sticker", "file", "system", ""])(
+      "returns empty for %s",
+      (type) => {
+        expect(parseFeishuMessageContent(type, JSON.stringify({}))).toEqual({
+          text: "",
+          parts: [],
+        });
+      },
+    );
+  });
+});
+
+describe("detectImageMime", () => {
+  it("detects PNG via 8-byte signature", () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]);
+    expect(detectImageMime(buf)).toBe("image/png");
+  });
+
+  it("detects JPEG via 3-byte signature", () => {
+    const buf = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]);
+    expect(detectImageMime(buf)).toBe("image/jpeg");
+  });
+
+  it.each([
+    ["GIF87a", [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]],
+    ["GIF89a", [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]],
+  ])("detects %s as image/gif", (_name, bytes) => {
+    expect(detectImageMime(Buffer.from(bytes))).toBe("image/gif");
+  });
+
+  it("detects WebP (RIFF...WEBP)", () => {
+    const buf = Buffer.from([
+      0x52, 0x49, 0x46, 0x46, // RIFF
+      0x00, 0x00, 0x00, 0x00, // size (don't care)
+      0x57, 0x45, 0x42, 0x50, // WEBP
+    ]);
+    expect(detectImageMime(buf)).toBe("image/webp");
+  });
+
+  it("returns null for unknown format", () => {
+    expect(detectImageMime(Buffer.from([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+  });
+
+  it("returns null for tiny buffers below signature length", () => {
+    expect(detectImageMime(Buffer.from([0x89, 0x50]))).toBeNull();
+    expect(detectImageMime(Buffer.from([]))).toBeNull();
+  });
+
+  it("returns null when GIF bytes are not GIF87a or GIF89a", () => {
+    const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x35, 0x61]); // GIF85a
+    expect(detectImageMime(buf)).toBeNull();
+  });
+
+  it("returns null when RIFF header lacks WEBP signature", () => {
+    const buf = Buffer.from([
+      0x52, 0x49, 0x46, 0x46,
+      0x00, 0x00, 0x00, 0x00,
+      0x41, 0x56, 0x49, 0x20, // AVI (not WEBP)
+    ]);
+    expect(detectImageMime(buf)).toBeNull();
+  });
+});
+
+describe("buildPromptContent", () => {
+  it("returns empty when no parts", () => {
+    expect(buildPromptContent([], new Map())).toEqual([]);
+  });
+
+  it("joins consecutive text parts with newline", () => {
+    const parts: ParsedContentPart[] = [
+      { type: "text", text: "one" },
+      { type: "text", text: "two" },
+    ];
+    expect(buildPromptContent(parts, new Map())).toEqual([
+      { type: "text", text: "one\ntwo" },
+    ]);
+  });
+
+  it("preserves text/image/text ordering", () => {
+    const parts: ParsedContentPart[] = [
+      { type: "text", text: "before" },
+      { type: "image-key", imageKey: "img_1" },
+      { type: "text", text: "after" },
+    ];
+    const data = new Map([
+      ["img_1", { data: "AAA", mimeType: "image/png" }],
+    ]);
+    expect(buildPromptContent(parts, data)).toEqual([
+      { type: "text", text: "before" },
+      { type: "image", data: "AAA", mimeType: "image/png" },
+      { type: "text", text: "after" },
+    ]);
+  });
+
+  it("drops image parts whose data is missing from the map", () => {
+    const parts: ParsedContentPart[] = [
+      { type: "text", text: "hi" },
+      { type: "image-key", imageKey: "missing" },
+      { type: "text", text: "bye" },
+    ];
+    expect(buildPromptContent(parts, new Map())).toEqual([
+      { type: "text", text: "hi\nbye" },
+    ]);
+  });
+
+  it("skips empty/whitespace-only text parts", () => {
+    const parts: ParsedContentPart[] = [
+      { type: "text", text: "   " },
+      { type: "text", text: "real" },
+      { type: "text", text: "" },
+    ];
+    expect(buildPromptContent(parts, new Map())).toEqual([
+      { type: "text", text: "real" },
+    ]);
+  });
+
+  it("emits multiple images in order with correct interleaved text", () => {
+    const parts: ParsedContentPart[] = [
+      { type: "image-key", imageKey: "a" },
+      { type: "text", text: "middle" },
+      { type: "image-key", imageKey: "b" },
+    ];
+    const data = new Map([
+      ["a", { data: "DA", mimeType: "image/jpeg" }],
+      ["b", { data: "DB", mimeType: "image/png" }],
+    ]);
+    expect(buildPromptContent(parts, data)).toEqual([
+      { type: "image", data: "DA", mimeType: "image/jpeg" },
+      { type: "text", text: "middle" },
+      { type: "image", data: "DB", mimeType: "image/png" },
+    ]);
+  });
+});

--- a/tests/unit/electron/channels/feishu/feishu-content-parser.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-content-parser.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   buildPromptContent,
-  detectImageMime,
   parseFeishuMessageContent,
   stripFeishuMentions,
   type ParsedContentPart,
 } from "../../../../../electron/main/channels/feishu/feishu-content-parser";
+import { detectImageMime } from "../../../../../electron/main/channels/shared/image-detector";
 
 describe("stripFeishuMentions", () => {
   it.each([

--- a/tests/unit/electron/channels/feishu/feishu-transport.test.ts
+++ b/tests/unit/electron/channels/feishu/feishu-transport.test.ts
@@ -233,4 +233,86 @@ describe("FeishuTransport", () => {
       });
     });
   });
+
+  describe("downloadMessageImage", () => {
+    function attachMessageResource(client: any, stream: AsyncIterable<unknown>): void {
+      client.im.messageResource = {
+        get: vi.fn().mockResolvedValue({
+          getReadableStream: () => stream,
+        }),
+      };
+    }
+
+    async function* streamOf(chunks: Buffer[]) {
+      for (const c of chunks) yield c;
+    }
+
+    it("returns concatenated buffer for a valid download", async () => {
+      const data = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+      attachMessageResource(larkClient, streamOf([data.subarray(0, 4), data.subarray(4)]));
+      const result = await transport.downloadMessageImage("m1", "img_1", 1024);
+      expect(result?.equals(data)).toBe(true);
+    });
+
+    it("passes correct params and path to the SDK", async () => {
+      attachMessageResource(larkClient, streamOf([Buffer.from([0])]));
+      await transport.downloadMessageImage("msg-x", "key-y", 999);
+      expect(larkClient.im.messageResource.get).toHaveBeenCalledWith({
+        params: { type: "image" },
+        path: { message_id: "msg-x", file_key: "key-y" },
+      });
+    });
+
+    it("returns null and warns when the stream exceeds maxBytes", async () => {
+      const big = Buffer.alloc(100, 1);
+      attachMessageResource(larkClient, streamOf([big]));
+      const result = await transport.downloadMessageImage("m1", "img_big", 10);
+      expect(result).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalled();
+      const msg = mockLogger.warn.mock.calls[0][0] as string;
+      expect(msg).toContain("img_big");
+      expect(msg).toContain("10");
+    });
+
+    it("destroys the stream when oversized", async () => {
+      const destroy = vi.fn();
+      const stream: any = (async function* () {
+        yield Buffer.alloc(100, 1);
+      })();
+      stream.destroy = destroy;
+      larkClient.im.messageResource = {
+        get: vi.fn().mockResolvedValue({ getReadableStream: () => stream }),
+      };
+      await transport.downloadMessageImage("m1", "k", 5);
+      expect(destroy).toHaveBeenCalled();
+    });
+
+    it("converts ArrayBuffer chunks to Buffer", async () => {
+      const arrBuf = new Uint8Array([1, 2, 3]).buffer;
+      attachMessageResource(larkClient, streamOf([arrBuf as any]));
+      const result = await transport.downloadMessageImage("m1", "img", 100);
+      expect(result?.equals(Buffer.from([1, 2, 3]))).toBe(true);
+    });
+
+    it("returns null and logs error when SDK throws", async () => {
+      larkClient.im.messageResource = {
+        get: vi.fn().mockRejectedValue(new Error("network down")),
+      };
+      const result = await transport.downloadMessageImage("m1", "k", 100);
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it("consumes a rate limiter token before downloading", async () => {
+      attachMessageResource(larkClient, streamOf([Buffer.from([0])]));
+      await transport.downloadMessageImage("m1", "k", 100);
+      expect(rateLimiter.consume).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns empty buffer when stream yields nothing", async () => {
+      attachMessageResource(larkClient, streamOf([]));
+      const result = await transport.downloadMessageImage("m1", "k", 100);
+      expect(result?.length).toBe(0);
+    });
+  });
 });

--- a/tests/unit/electron/channels/shared/image-detector.test.ts
+++ b/tests/unit/electron/channels/shared/image-detector.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { detectImageMime } from "../../../../../electron/main/channels/shared/image-detector";
+
+describe("detectImageMime", () => {
+  it("detects PNG by 8-byte signature", () => {
+    const buf = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.alloc(16),
+    ]);
+    expect(detectImageMime(buf)).toBe("image/png");
+  });
+
+  it("detects JPEG by 3-byte SOI", () => {
+    const buf = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff]), Buffer.alloc(16)]);
+    expect(detectImageMime(buf)).toBe("image/jpeg");
+  });
+
+  it.each([
+    ["GIF87a", [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]],
+    ["GIF89a", [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]],
+  ])("detects %s", (_label, bytes) => {
+    expect(detectImageMime(Buffer.from(bytes))).toBe("image/gif");
+  });
+
+  it("detects WebP via RIFF...WEBP", () => {
+    const buf = Buffer.from([
+      0x52, 0x49, 0x46, 0x46,
+      0, 0, 0, 0,
+      0x57, 0x45, 0x42, 0x50,
+    ]);
+    expect(detectImageMime(buf)).toBe("image/webp");
+  });
+
+  it("returns null for unknown headers and tiny buffers", () => {
+    expect(detectImageMime(Buffer.from([0x00, 0x01, 0x02, 0x03]))).toBeNull();
+    expect(detectImageMime(Buffer.from([]))).toBeNull();
+    expect(detectImageMime(Buffer.from([0x89]))).toBeNull();
+  });
+
+  it("returns null when GIF marker is not 87a or 89a", () => {
+    const buf = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x33, 0x61]);
+    expect(detectImageMime(buf)).toBeNull();
+  });
+
+  it("returns null when RIFF header lacks WEBP marker", () => {
+    const buf = Buffer.from([
+      0x52, 0x49, 0x46, 0x46,
+      0, 0, 0, 0,
+      0x57, 0x41, 0x56, 0x45, // "WAVE" instead
+    ]);
+    expect(detectImageMime(buf)).toBeNull();
+  });
+});

--- a/tests/unit/electron/channels/teams/teams-adapter.test.ts
+++ b/tests/unit/electron/channels/teams/teams-adapter.test.ts
@@ -329,7 +329,7 @@ describe("TeamsAdapter", () => {
         recipient: { id: "bot" },
         text: "hi",
       });
-      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "aad1", "hi");
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("c1", "aad1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("routes group with mention to handleGroupMessage", async () => {
@@ -500,7 +500,7 @@ describe("TeamsAdapter", () => {
     it("falls back to showProjectList when nothing selected", async () => {
       const a = makeP2P();
       a.showProjectList = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.showProjectList).toHaveBeenCalledWith("c1");
     });
 
@@ -512,8 +512,8 @@ describe("TeamsAdapter", () => {
         lastActiveAt: Date.now(), messageQueue: [], processing: true,
       });
       a.enqueueP2PMessage = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("creates temp session if last project selected and no temp exists", async () => {
@@ -523,7 +523,7 @@ describe("TeamsAdapter", () => {
         directory: "/d", engineType: "claude", projectId: "p",
       });
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
 
@@ -535,7 +535,7 @@ describe("TeamsAdapter", () => {
         projects: [{ id: "p1", name: "alpha", directory: "/a", engineType: "claude" }],
       });
       a.showSessionListForProject = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "1");
+      await a.handleP2PMessage("c1", "u1", "1", [{ type: "text", text: "1" }]);
       expect(a.showSessionListForProject).toHaveBeenCalled();
     });
   });
@@ -744,7 +744,7 @@ describe("TeamsAdapter", () => {
         "hi",
       );
       expect(a.sessionMapper.getTempSession("c1")?.conversationId).toBe("sess-2");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("createTempSessionAndSend reports error on failure", async () => {

--- a/tests/unit/electron/channels/telegram/telegram-adapter.test.ts
+++ b/tests/unit/electron/channels/telegram/telegram-adapter.test.ts
@@ -337,7 +337,7 @@ describe("TelegramAdapter", () => {
         date: 0,
         text: "hi",
       });
-      expect(a.handleP2PMessage).toHaveBeenCalledWith("100", "1", "hi");
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("100", "1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.sessionMapper.getP2PChat("100")).toBeDefined();
     });
 
@@ -493,8 +493,8 @@ describe("TelegramAdapter", () => {
         processing: true,
       });
       a.enqueueP2PMessage = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("creates temp session if last project selected and no temp exists", async () => {
@@ -506,7 +506,7 @@ describe("TelegramAdapter", () => {
         projectId: "p",
       });
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
 
@@ -742,7 +742,7 @@ describe("TelegramAdapter", () => {
         "hi",
       );
       expect(a.sessionMapper.getTempSession("c1")?.conversationId).toBe("sess-2");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("createTempSessionAndSend reports error on createSession failure", async () => {

--- a/tests/unit/electron/channels/wecom/wecom-adapter.test.ts
+++ b/tests/unit/electron/channels/wecom/wecom-adapter.test.ts
@@ -227,7 +227,7 @@ describe("WeComAdapter", () => {
         toUserName: "corp", fromUserName: "u1", createTime: 0,
         msgType: "text", content: "hi", msgId: "m1", agentId: 1,
       });
-      expect(a.handleP2PMessage).toHaveBeenCalledWith("user:u1", "u1", "hi");
+      expect(a.handleP2PMessage).toHaveBeenCalledWith("user:u1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.sessionMapper.getP2PChat("user:u1")).toBeDefined();
     });
   });
@@ -395,7 +395,7 @@ describe("WeComAdapter", () => {
     it("falls back to showProjectList when nothing selected", async () => {
       const a = makeP2P();
       a.showProjectList = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.showProjectList).toHaveBeenCalledWith("c1");
     });
 
@@ -407,8 +407,8 @@ describe("WeComAdapter", () => {
         lastActiveAt: Date.now(), messageQueue: [], processing: true,
       });
       a.enqueueP2PMessage = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("creates temp session when last project selected and no temp exists", async () => {
@@ -418,7 +418,7 @@ describe("WeComAdapter", () => {
         directory: "/d", engineType: "claude", projectId: "p",
       });
       a.createTempSessionAndSend = vi.fn(async () => undefined);
-      await a.handleP2PMessage("c1", "u1", "hi");
+      await a.handleP2PMessage("c1", "u1", "hi", [{ type: "text", text: "hi" }]);
       expect(a.createTempSessionAndSend).toHaveBeenCalled();
     });
   });
@@ -624,7 +624,7 @@ describe("WeComAdapter", () => {
         "hi",
       );
       expect(a.sessionMapper.getTempSession("c1")?.conversationId).toBe("s2");
-      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi");
+      expect(a.enqueueP2PMessage).toHaveBeenCalledWith("c1", "hi", [{ type: "text", text: "hi" }]);
     });
 
     it("createTempSessionAndSend reports error on failure", async () => {

--- a/tests/unit/electron/channels/wecom/wecom-transport.test.ts
+++ b/tests/unit/electron/channels/wecom/wecom-transport.test.ts
@@ -1,0 +1,304 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLogger = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  verbose: vi.fn(),
+  debug: vi.fn(),
+  silly: vi.fn(),
+}));
+
+vi.mock("../../../../../electron/main/services/logger", () => ({
+  channelLog: mockLogger,
+}));
+
+const fetchMock = vi.hoisted(() => vi.fn());
+vi.stubGlobal("fetch", fetchMock);
+
+import { WeComTransport } from "../../../../../electron/main/channels/wecom/wecom-transport";
+
+function makeTokenManager(token = "wecom-token") {
+  return {
+    getToken: vi.fn().mockResolvedValue(token),
+    invalidate: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function makeRateLimiter() {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return { consume: vi.fn().mockResolvedValue(undefined) } as any;
+}
+
+function okJson(body: unknown) {
+  return { ok: true, json: () => Promise.resolve(body) };
+}
+
+function okBinary(bytes: number, headers: Record<string, string> = {}) {
+  const buf = new Uint8Array(bytes);
+  return {
+    ok: true,
+    headers: { get: (k: string) => headers[k.toLowerCase()] ?? null },
+    arrayBuffer: () => Promise.resolve(buf.buffer),
+  };
+}
+
+describe("WeComTransport", () => {
+  let transport: WeComTransport;
+  let tokenManager: ReturnType<typeof makeTokenManager>;
+  let rateLimiter: ReturnType<typeof makeRateLimiter>;
+  const AGENT_ID = 1000002;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tokenManager = makeTokenManager();
+    rateLimiter = makeRateLimiter();
+    transport = new WeComTransport(tokenManager, rateLimiter, AGENT_ID);
+  });
+
+  describe("sendText", () => {
+    it("dispatches to user when target uses 'user:' prefix", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", msgid: "m-user-1" }));
+      const id = await transport.sendText("user:alice", "hi");
+      expect(id).toBe("m-user-1");
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://qyapi.weixin.qq.com/cgi-bin/message/send?access_token=wecom-token");
+      expect(JSON.parse(init.body)).toEqual({
+        touser: "alice",
+        msgtype: "text",
+        agentid: AGENT_ID,
+        text: { content: "hi" },
+      });
+    });
+
+    it("dispatches to user when target has no prefix (default)", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", msgid: "m-default" }));
+      const id = await transport.sendText("bob", "yo");
+      expect(id).toBe("m-default");
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body).touser).toBe("bob");
+    });
+
+    it("dispatches to group when target uses 'group:' prefix", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok" }));
+      const id = await transport.sendText("group:g1", "hello");
+      expect(id).toMatch(/^group_g1_\d+$/);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("https://qyapi.weixin.qq.com/cgi-bin/appchat/send?access_token=wecom-token");
+      expect(JSON.parse(init.body)).toEqual({
+        chatid: "g1",
+        msgtype: "text",
+        text: { content: "hello" },
+      });
+    });
+
+    it("returns empty string and logs when API returns non-zero errcode (user)", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 40001, errmsg: "bad token" }));
+      const id = await transport.sendText("user:u1", "x");
+      expect(id).toBe("");
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("bad token"));
+    });
+
+    it("returns empty string and logs when API returns non-zero errcode (group)", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 40031, errmsg: "invalid chat" }));
+      const id = await transport.sendText("group:g2", "x");
+      expect(id).toBe("");
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining("invalid chat"));
+    });
+
+    it("returns empty string when fetch throws (user)", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("network down"));
+      const id = await transport.sendText("user:u1", "x");
+      expect(id).toBe("");
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it("returns empty string when fetch throws (group)", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("network down"));
+      const id = await transport.sendText("group:g1", "x");
+      expect(id).toBe("");
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it("falls back to empty msgid when API omits one", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok" }));
+      const id = await transport.sendText("user:u1", "x");
+      expect(id).toBe("");
+    });
+
+    it("consumes rate limiter and fetches access token", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", msgid: "m1" }));
+      await transport.sendText("user:u", "x");
+      expect(rateLimiter.consume).toHaveBeenCalledTimes(1);
+      expect(tokenManager.getToken).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("updateText", () => {
+    it("is a no-op (WeCom messages are immutable)", async () => {
+      await expect(transport.updateText("m1", "new")).resolves.toBeUndefined();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sendRichContent / sendMarkdown", () => {
+    it("sendRichContent posts markdown to user endpoint", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", msgid: "md-1" }));
+      const id = await transport.sendRichContent("user:u1", "# hello");
+      expect(id).toBe("md-1");
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body)).toEqual({
+        touser: "u1",
+        msgtype: "markdown",
+        agentid: AGENT_ID,
+        markdown: { content: "# hello" },
+      });
+    });
+
+    it("sendRichContent posts markdown to group endpoint", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok" }));
+      const id = await transport.sendRichContent("group:g1", "# hi");
+      expect(id).toMatch(/^group_g1_\d+$/);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/appchat/send");
+      expect(JSON.parse(init.body)).toEqual({
+        chatid: "g1",
+        msgtype: "markdown",
+        markdown: { content: "# hi" },
+      });
+    });
+
+    it("sendMarkdown delegates to sendRichContent", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", msgid: "md-2" }));
+      const id = await transport.sendMarkdown("user:u1", "# yo");
+      expect(id).toBe("md-2");
+    });
+  });
+
+  describe("deleteMessage", () => {
+    it("calls /message/recall with msgid", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok" }));
+      await transport.deleteMessage("msg-1");
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe(
+        "https://qyapi.weixin.qq.com/cgi-bin/message/recall?access_token=wecom-token",
+      );
+      expect(JSON.parse(init.body)).toEqual({ msgid: "msg-1" });
+    });
+
+    it("is a no-op when messageId is empty", async () => {
+      await transport.deleteMessage("");
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("throws when API returns non-zero errcode", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 40001, errmsg: "expired" }));
+      await expect(transport.deleteMessage("msg-9")).rejects.toThrow(/expired/);
+    });
+  });
+
+  describe("createGroup", () => {
+    it("returns the chatid created by WeCom", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", chatid: "g-new" }));
+      const id = await transport.createGroup("Team", "owner", ["a", "b"]);
+      expect(id).toBe("g-new");
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/appchat/create");
+      expect(JSON.parse(init.body)).toEqual({
+        name: "Team",
+        owner: "owner",
+        userlist: ["a", "b"],
+      });
+    });
+
+    it("includes optional chatid when passed", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok", chatid: "g-fixed" }));
+      const id = await transport.createGroup("Team", "owner", ["a"], "g-fixed");
+      expect(id).toBe("g-fixed");
+      const [, init] = fetchMock.mock.calls[0];
+      expect(JSON.parse(init.body).chatid).toBe("g-fixed");
+    });
+
+    it("returns null on error", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 50001, errmsg: "bad members" }));
+      const id = await transport.createGroup("Team", "owner", ["a"]);
+      expect(id).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+
+    it("returns null when fetch throws", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("boom"));
+      const id = await transport.createGroup("Team", "owner", ["a"]);
+      expect(id).toBeNull();
+    });
+
+    it("returns null when chatid is missing in success response", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok" }));
+      const id = await transport.createGroup("Team", "owner", ["a"]);
+      expect(id).toBeNull();
+    });
+  });
+
+  describe("updateGroup", () => {
+    it("returns true on success", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 0, errmsg: "ok" }));
+      const ok = await transport.updateGroup("g1", { name: "New", add_user_list: ["c"] });
+      expect(ok).toBe(true);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toContain("/appchat/update");
+      expect(JSON.parse(init.body)).toEqual({
+        chatid: "g1",
+        name: "New",
+        add_user_list: ["c"],
+      });
+    });
+
+    it("returns false on non-zero errcode", async () => {
+      fetchMock.mockResolvedValueOnce(okJson({ errcode: 40031, errmsg: "no such chat" }));
+      const ok = await transport.updateGroup("g1", { name: "n" });
+      expect(ok).toBe(false);
+    });
+
+    it("returns false when fetch throws", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("net"));
+      const ok = await transport.updateGroup("g1", { name: "n" });
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe("downloadImageFromUrl", () => {
+    it("returns a Buffer when fetch succeeds", async () => {
+      fetchMock.mockResolvedValueOnce(okBinary(128, { "content-length": "128" }));
+      const buf = await transport.downloadImageFromUrl("https://cdn/img.jpg", 1024);
+      expect(buf).toBeInstanceOf(Buffer);
+      expect(buf!.length).toBe(128);
+    });
+
+    it("returns null when HTTP status is not ok", async () => {
+      fetchMock.mockResolvedValueOnce({ ok: false, status: 404 });
+      const buf = await transport.downloadImageFromUrl("https://cdn/missing", 1024);
+      expect(buf).toBeNull();
+    });
+
+    it("returns null when content-length exceeds limit", async () => {
+      fetchMock.mockResolvedValueOnce(okBinary(0, { "content-length": "999999" }));
+      const buf = await transport.downloadImageFromUrl("https://cdn/big", 1024);
+      expect(buf).toBeNull();
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("999999"));
+    });
+
+    it("returns null when actual body exceeds limit (no content-length header)", async () => {
+      fetchMock.mockResolvedValueOnce(okBinary(2048));
+      const buf = await transport.downloadImageFromUrl("https://cdn/img.jpg", 1024);
+      expect(buf).toBeNull();
+    });
+
+    it("returns null when fetch throws", async () => {
+      fetchMock.mockRejectedValueOnce(new Error("dns"));
+      const buf = await transport.downloadImageFromUrl("https://cdn/img.jpg", 1024);
+      expect(buf).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/electron/channels/weixin-ilink/weixin-ilink-adapter.test.ts
+++ b/tests/unit/electron/channels/weixin-ilink/weixin-ilink-adapter.test.ts
@@ -261,7 +261,7 @@ describe("WeixinIlinkAdapter", () => {
       expect(out).toBe("hello");
     });
 
-    it("renders [Image] / [Voice] / [File] / [Video] for non-text types", () => {
+    it("renders [Voice] / [File] / [Video] for non-text types and omits image", () => {
       const adapter = new WeixinIlinkAdapter() as any;
       const out = adapter.extractText({
         item_list: [
@@ -271,7 +271,7 @@ describe("WeixinIlinkAdapter", () => {
           { type: 5 },
         ],
       });
-      expect(out).toContain("[Image]");
+      expect(out).not.toContain("[Image]");
       expect(out).toContain("[Voice]");
       expect(out).toContain("[File: doc.pdf]");
       expect(out).toContain("[Video]");

--- a/tests/unit/electron/engines/codex/converters.test.ts
+++ b/tests/unit/electron/engines/codex/converters.test.ts
@@ -2022,6 +2022,55 @@ describe("createUserMessage - default timestamp", () => {
     expect(msg.time.created).toBeGreaterThanOrEqual(before);
     expect(msg.time.created).toBeLessThanOrEqual(after);
   });
+
+  it("renders image attachments as FileParts after the text part", () => {
+    const msg = createUserMessage("sess", "look at this", 1000, [
+      { type: "image", data: "AAAA", mimeType: "image/png" },
+      { type: "image", data: "BBBB", mimeType: "image/jpeg" },
+    ]);
+    expect(msg.parts).toHaveLength(3);
+    expect(msg.parts[0]).toMatchObject({ type: "text", text: "look at this" });
+    expect(msg.parts[1]).toMatchObject({
+      type: "file",
+      mime: "image/png",
+      filename: "image-1.png",
+      url: "data:image/png;base64,AAAA",
+    });
+    expect(msg.parts[2]).toMatchObject({
+      type: "file",
+      mime: "image/jpeg",
+      filename: "image-2.jpeg",
+      url: "data:image/jpeg;base64,BBBB",
+    });
+  });
+
+  it("emits only FileParts for an image-only user message", () => {
+    const msg = createUserMessage("sess", "", 1000, [
+      { type: "image", data: "AAAA", mimeType: "image/webp" },
+    ]);
+    expect(msg.parts).toHaveLength(1);
+    expect(msg.parts[0]).toMatchObject({
+      type: "file",
+      mime: "image/webp",
+      filename: "image-1.webp",
+      url: "data:image/webp;base64,AAAA",
+    });
+  });
+
+  it("falls back to empty text part when text and images are both empty", () => {
+    const msg = createUserMessage("sess", "", 1000, []);
+    expect(msg.parts).toHaveLength(1);
+    expect(msg.parts[0]).toMatchObject({ type: "text", text: "" });
+  });
+
+  it("skips invalid image entries without data", () => {
+    const msg = createUserMessage("sess", "x", 1000, [
+      { type: "image", data: "", mimeType: "image/png" },
+      { type: "text", text: "ignored" },
+    ]);
+    expect(msg.parts).toHaveLength(1);
+    expect(msg.parts[0]).toMatchObject({ type: "text", text: "x" });
+  });
 });
 
 describe("applyHistoricalToolTiming - error status branch", () => {

--- a/tests/unit/electron/engines/copilot/converters.test.ts
+++ b/tests/unit/electron/engines/copilot/converters.test.ts
@@ -551,6 +551,50 @@ describe('copilot-converters', () => {
       expect(msg.parts[0].type).toBe('text');
       expect((msg.parts[0] as TextPart).text).toBe('hello');
     });
+
+    it('emits a FilePart per image with a data: URL', () => {
+      const msg = createUserMessage(sessionId, 'caption', tsMs, [
+        { data: 'AAA', mimeType: 'image/png' },
+        { data: 'BBB', mimeType: 'image/jpeg' },
+      ]);
+      expect(msg.parts).toHaveLength(3);
+      expect(msg.parts[0].type).toBe('text');
+      expect((msg.parts[0] as TextPart).text).toBe('caption');
+      const fp1 = msg.parts[1] as any;
+      expect(fp1.type).toBe('file');
+      expect(fp1.mime).toBe('image/png');
+      expect(fp1.url).toBe('data:image/png;base64,AAA');
+      expect(fp1.filename).toBe('image.png');
+      const fp2 = msg.parts[2] as any;
+      expect(fp2.type).toBe('file');
+      expect(fp2.mime).toBe('image/jpeg');
+      expect(fp2.url).toBe('data:image/jpeg;base64,BBB');
+      expect(fp2.filename).toBe('image.jpeg');
+    });
+
+    it('emits only image FileParts when text is empty', () => {
+      const msg = createUserMessage(sessionId, '', tsMs, [
+        { data: 'AAA', mimeType: 'image/gif' },
+      ]);
+      expect(msg.parts).toHaveLength(1);
+      expect((msg.parts[0] as any).type).toBe('file');
+      expect((msg.parts[0] as any).mime).toBe('image/gif');
+    });
+
+    it('falls back to a single empty TextPart when both text and images are missing', () => {
+      const msg = createUserMessage(sessionId, '', tsMs);
+      expect(msg.parts).toHaveLength(1);
+      expect(msg.parts[0].type).toBe('text');
+      expect((msg.parts[0] as TextPart).text).toBe('');
+    });
+
+    it('defaults mimeType to image/png when missing', () => {
+      const msg = createUserMessage(sessionId, '', tsMs, [
+        { data: 'AAA', mimeType: '' as any },
+      ]);
+      expect((msg.parts[0] as any).mime).toBe('image/png');
+      expect((msg.parts[0] as any).url).toBe('data:image/png;base64,AAA');
+    });
   });
 
   describe('buildToolTitle', () => {

--- a/tests/unit/electron/gateway/engine-manager.test.ts
+++ b/tests/unit/electron/gateway/engine-manager.test.ts
@@ -1959,7 +1959,7 @@ describe("EngineManager", () => {
       adapterA.createSession.mockResolvedValue({ id: "eng-pum", engineMeta: {} } as any);
     });
 
-    it("persists image content as text placeholder", async () => {
+    it("persists image content as a FilePart with inline data URL", async () => {
       await engineManager.sendMessage("conv1", [
         { type: "image", data: "base64abc", mimeType: "image/png" } as any,
       ]);
@@ -1969,11 +1969,14 @@ describe("EngineManager", () => {
       );
       expect(appendCall).toBeDefined();
       const msg = appendCall[1];
-      expect(msg.parts[0].text).toContain("[Image:");
-      expect(msg.parts[0].text).toContain("image/png");
+      const part = msg.parts[0];
+      expect(part.type).toBe("file");
+      expect(part.mime).toBe("image/png");
+      expect(part.filename).toBe("image-1.png");
+      expect(part.url).toBe("data:image/png;base64,base64abc");
     });
 
-    it("uses 'image' as fallback when mimeType is absent", async () => {
+    it("uses 'image/png' as fallback when mimeType is absent", async () => {
       await engineManager.sendMessage("conv1", [
         { type: "image", data: "base64abc" } as any,
       ]);
@@ -1981,7 +1984,35 @@ describe("EngineManager", () => {
       const appendCall = (conversationStore.appendMessage as any).mock.calls.find(
         (c: any[]) => c[0] === "conv1",
       );
-      expect(appendCall[1].parts[0].text).toContain("[Image: image]");
+      const part = appendCall[1].parts[0];
+      expect(part.type).toBe("file");
+      expect(part.mime).toBe("image/png");
+      expect(part.filename).toBe("image-1.png");
+      expect(part.url).toBe("data:image/png;base64,base64abc");
+    });
+
+    it("persists mixed text and multiple images preserving order and indexing image filenames", async () => {
+      await engineManager.sendMessage("conv1", [
+        { type: "text", text: "hi" } as any,
+        { type: "image", data: "AAA", mimeType: "image/jpeg" } as any,
+        { type: "image", data: "BBB", mimeType: "image/webp" } as any,
+      ]);
+
+      const appendCall = (conversationStore.appendMessage as any).mock.calls.find(
+        (c: any[]) => c[0] === "conv1",
+      );
+      const parts = appendCall[1].parts;
+      expect(parts).toHaveLength(3);
+      expect(parts[0].type).toBe("text");
+      expect(parts[0].text).toBe("hi");
+      expect(parts[1].type).toBe("file");
+      expect(parts[1].mime).toBe("image/jpeg");
+      expect(parts[1].filename).toBe("image-1.jpeg");
+      expect(parts[1].url).toBe("data:image/jpeg;base64,AAA");
+      expect(parts[2].type).toBe("file");
+      expect(parts[2].mime).toBe("image/webp");
+      expect(parts[2].filename).toBe("image-2.webp");
+      expect(parts[2].url).toBe("data:image/webp;base64,BBB");
     });
 
     it("does NOT persist when parts array would be empty", async () => {

--- a/tests/unit/shared/image-limits.test.ts
+++ b/tests/unit/shared/image-limits.test.ts
@@ -5,6 +5,7 @@ import {
   MAX_IMAGE_SIZE_BYTES,
   MAX_TOTAL_IMAGE_BYTES,
   isAcceptedImageMime,
+  mimeToFileExtension,
   validateImageAddition,
   type ImageCandidate,
 } from "../../../shared/image-limits";
@@ -79,4 +80,30 @@ describe("validateImageAddition", () => {
       expect(validateImageAddition(existing, png(fit))).toEqual({ ok: true });
     }
   });
+});
+
+describe("mimeToFileExtension", () => {
+  it.each([
+    ["image/png", "png"],
+    ["image/jpeg", "jpeg"],
+    ["image/gif", "gif"],
+    ["image/webp", "webp"],
+  ])("returns the subtype for plain MIME %s", (mime, expected) => {
+    expect(mimeToFileExtension(mime)).toBe(expected);
+  });
+
+  it("strips compound suffix (image/svg+xml → svg)", () => {
+    expect(mimeToFileExtension("image/svg+xml")).toBe("svg");
+  });
+
+  it("strips media-type parameters (image/png; q=0.9 → png)", () => {
+    expect(mimeToFileExtension("image/png; q=0.9")).toBe("png");
+  });
+
+  it.each([["png", "png"], ["", "png"], ["image", "png"], ["image/", "png"]])(
+    "falls back to png for malformed input %j",
+    (mime, expected) => {
+      expect(mimeToFileExtension(mime)).toBe(expected);
+    },
+  );
 });

--- a/tests/unit/shared/image-limits.test.ts
+++ b/tests/unit/shared/image-limits.test.ts
@@ -106,4 +106,18 @@ describe("mimeToFileExtension", () => {
       expect(mimeToFileExtension(mime)).toBe(expected);
     },
   );
+
+  it.each([
+    "image/..\\..\\secret",
+    "image/../../etc/passwd",
+    "image/png/../evil",
+    "image/png evil",
+    "image/<script>",
+  ])("falls back to png for path-unsafe subtype %j", (mime) => {
+    expect(mimeToFileExtension(mime)).toBe("png");
+  });
+
+  it("normalizes uppercase subtypes (image/PNG → png)", () => {
+    expect(mimeToFileExtension("image/PNG")).toBe("png");
+  });
 });

--- a/tests/unit/shared/image-limits.test.ts
+++ b/tests/unit/shared/image-limits.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  ACCEPTED_IMAGE_MIME_TYPES,
+  MAX_IMAGES_PER_MESSAGE,
+  MAX_IMAGE_SIZE_BYTES,
+  MAX_TOTAL_IMAGE_BYTES,
+  isAcceptedImageMime,
+  validateImageAddition,
+  type ImageCandidate,
+} from "../../../shared/image-limits";
+
+describe("isAcceptedImageMime", () => {
+  it.each(ACCEPTED_IMAGE_MIME_TYPES.map((m) => [m]))(
+    "accepts %s",
+    (mime) => {
+      expect(isAcceptedImageMime(mime)).toBe(true);
+    },
+  );
+
+  it.each([
+    ["application/pdf"],
+    ["text/plain"],
+    ["image/svg+xml"],
+    ["image/heic"],
+    [""],
+  ])("rejects %s", (mime) => {
+    expect(isAcceptedImageMime(mime)).toBe(false);
+  });
+});
+
+describe("validateImageAddition", () => {
+  const png = (size: number): ImageCandidate => ({ mimeType: "image/png", size });
+
+  it("accepts a small first image", () => {
+    expect(validateImageAddition([], png(100))).toEqual({ ok: true });
+  });
+
+  it("rejects non-whitelisted mime types", () => {
+    const r = validateImageAddition([], { mimeType: "image/svg+xml", size: 100 });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("mime");
+  });
+
+  it("rejects oversized single images", () => {
+    const r = validateImageAddition([], png(MAX_IMAGE_SIZE_BYTES + 1));
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("size");
+  });
+
+  it("allows exactly the per-image cap", () => {
+    expect(validateImageAddition([], png(MAX_IMAGE_SIZE_BYTES))).toEqual({ ok: true });
+  });
+
+  it("rejects when count limit is already reached", () => {
+    const existing: ImageCandidate[] = Array.from(
+      { length: MAX_IMAGES_PER_MESSAGE },
+      () => png(10),
+    );
+    const r = validateImageAddition(existing, png(10));
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe("count");
+  });
+
+  it("returns size/count/mime correctly when boundaries are crossed", () => {
+    // Under current caps (3 MB per image × 4 images = 12 MB total), the
+    // `total` branch is mathematically unreachable without first violating
+    // `size` or `count`. The two reachable rejections are exercised above;
+    // this test pins the boundary behaviour so future tightening of caps
+    // doesn't silently break the contract.
+    const slot = MAX_IMAGE_SIZE_BYTES;
+    const existing: ImageCandidate[] = Array.from(
+      { length: MAX_IMAGES_PER_MESSAGE - 1 },
+      () => png(slot),
+    );
+    // Adding the largest allowed image fills the cap exactly → still ok.
+    const remaining = MAX_TOTAL_IMAGE_BYTES - existing.length * slot;
+    const fit = Math.min(slot, remaining);
+    if (fit > 0) {
+      expect(validateImageAddition(existing, png(fit))).toEqual({ ok: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds image attachment support for messages received via the Feishu (Lark) channel and ensures images render in the codemux webui both in live updates and after session reload.

## Background

Previously, Feishu image messages were silently dropped on their way to the engine, and even when the engine adapters did receive an image, it was rendered as the literal text `[Image: image/jpeg]` after a page reload or session switch. This PR fixes the full pipeline end-to-end.

## Changes

### 1. `fix(feishu): include image attachments in messages sent to engine` (fcc60f1)
- New pure parser `feishu-content-parser.ts` for text/image/post messages with `@_user_N` mention stripping.
- New `downloadMessageImage` transport method backed by Lark SDK `messageResource.get`, with magic-byte mime detection (PNG/JPEG/GIF/WebP) and a 3 MB per-image cap.
- Adapter refactor to thread `MessagePromptContent[]` through engine-send paths; downloads deferred until after command/pending-question/selection routing.
- Limits match the frontend: 3 MB per image, max 4 images per message.

### 2. `fix(engines): emit FileParts on user message so image attachments render in webui` (098ee0d)
- `copilot/converters.ts` `createUserMessage` now accepts `images?` and emits one `FilePart` per image.
- `claude/index.ts` gains a `buildUserMessageParts` helper used on both enqueue and normal send paths.
- `Chat.tsx` optimistic temp user message now includes FileParts for image attachments (browser-uploaded images show immediately instead of only after the engine echoes them back).

### 3. `fix(gateway): persist user message images as FilePart so they survive reload` (af94a3d)
- `engine-manager.ts` `persistUserMessage` used to save image content as a `[Image: <mime>]` text placeholder to "avoid bloating conversation files".
- The placeholder is what the webui saw whenever a conversation was read back from disk, defeating the live FilePart rendering.
- Now persists images as `FilePart` with inline `data:<mime>;base64,<b64>` URLs. Total bloat is bounded (3 MB × 4 max per message), already format-compatible with the live update path and `share/part.tsx` rendering.

## Testing

- Full unit suite: **3332/3332 passing** (3327 baseline + 5 new tests for `createUserMessage` images, plus 48 parser + 11 adapter pipeline + 8 transport download tests in the Feishu changes; the gateway image-persistence tests were updated to assert the new FilePart shape).
- `npx tsc --noEmit` clean.
- Manually verified end-to-end with GitHub Copilot as the engine: sending an image via Feishu now appears as an image in the codemux webui both in the live message stream and after a page reload.

## Notes

- `persistUserMessage` no longer extracts `firstPrompt` from image-only messages (the old `[Image: …]` placeholder would have been used as the title). Image-only sessions will instead fall back to whatever default title resolution the app uses. This is a minor improvement IMO — `[Image: image/jpeg]` was never a good title.