### PR TITLE
fix(ci): handle bun state-dir.ts call in server-dev-script test mock

### DIFF
--- a/tests/unit/shared/server-dev-script.test.ts
+++ b/tests/unit/shared/server-dev-script.test.ts
@@ -39,6 +39,13 @@ elif [ "\${1:-}" = "scripts/server-auth.ts" ] && [ "\${2:-}" = "access-requests"
   else
     echo "[!] No pending requests."
   fi
+elif [[ "\${1:-}" == */state-dir.ts ]]; then
+  # Mirror getGlobalServerStateRoot() in scripts/state-dir.ts for the
+  # non-isolated path that server-dev.sh uses. Keep this in sync with the
+  # production implementation: XDG_STATE_HOME wins, otherwise fall back to
+  # \$HOME/.local/state, with "codemux-server" appended.
+  base="\${XDG_STATE_HOME:-\${HOME}/.local/state}"
+  printf '%s/codemux-server' "\$base"
 else
   echo "Unexpected bun args: $*" >&2
   exit 1


### PR DESCRIPTION
## Problem

Main CI on `ubuntu-latest` is failing on the `Unit Tests` job after PR #148 (`feat(server-dev): server restart preserving managed quick tunnel`) was merged. Failed run: https://github.com/realDuang/codemux/actions/runs/26145217412/job/76899145150

All three cases in `tests/unit/shared/server-dev-script.test.ts` fail with:

```
Error: Command failed: bash /tmp/codemux-server-dev-XXXX/scripts/server-dev.sh start --replace --tunnel
Unexpected bun args: /tmp/codemux-server-dev-XXXX/scripts/state-dir.ts /tmp/codemux-server-dev-XXXX
```

macOS and Windows pass because the suite uses `describe.skipIf(process.platform !== "linux")`, so the regression was only visible on Ubuntu.

## Root cause

PR #148 introduced `scripts/state-dir.ts` and changed `scripts/server-dev.sh` to resolve its state directory via

```bash
STATE_DIR=$(bun "$SCRIPT_DIR/state-dir.ts" "$REPO_DIR")
```

The test's `FAKE_BUN` mock was not updated for this new call. It only recognized `bun run dev` and `bun scripts/server-auth.ts ...`, so any `state-dir.ts` invocation hit the catch-all branch:

```bash
else
  echo "Unexpected bun args: $*" >&2
  exit 1
fi
```

Combined with `set -euo pipefail`, the failed command substitution aborts `server-dev.sh` before `start` does any work, causing all three integration cases to fail.

## Fix

Add a new `FAKE_BUN` branch that mirrors `getGlobalServerStateRoot()` in `scripts/state-dir.ts` for the non-isolated path `server-dev.sh` uses:

- Prefer `XDG_STATE_HOME` (test already sets this to `<root>/state`).
- Fall back to `$HOME/.local/state`.
- Append the `codemux-server` segment.

The mocked output `<root>/state/codemux-server` matches `repo.stateDir` already constructed in `createTestRepo()`, so no test logic has to change.

## Verification

- `bun run typecheck` — pass
- `bun run lint` — 0 errors (warnings are pre-existing)
- `bun run test:unit` (macOS local) — 3432 passed, 3 skipped (Linux-only suite skipped as expected)
- Manual extraction of the updated mock script confirms it emits `${XDG_STATE_HOME}/codemux-server` for `*/state-dir.ts` calls and preserves existing branches.

CI on Ubuntu should now turn green again.