### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codemux",
-  "version": "1.6.4",
+  "version": "1.7.0",
   "type": "module",
   "description": "A unified AI coding assistant client - access multiple AI coding engines from any device via desktop app or web interface",
   "author": "realDuang",


### PR DESCRIPTION
## Summary
Bump `package.json` version from `1.6.4` to `1.7.0` (minor bump).

Many features have landed since v1.6.4, so a minor bump is the right level per semver.

### Highlights since v1.6.4

**Features**
- `feat: integrated terminal panel (Gateway-based) with VS Code-style enhancements` (#146)
- `feat(server-dev): server:dev:isolated — dev:isolated parity for the headless server` (#147)
- `feat(server-dev): server restart preserving managed quick tunnel` (#148)
- `feat(channels): add shared image-limits + format detector`
- Inbound image attachment support across channels: dingtalk / wecom / telegram / teams
- `feat(weixin-ilink): friendly notice that inbound images are unsupported`

**Refactor**
- `refactor(channels): make BaseSessionMapper queue item generic + Feishu uses shared`

**Fixes**
- `fix(feishu): include image attachments in messages sent to engine`
- `fix(engines): emit FileParts on user message so image attachments render in webui`
- `fix(gateway): persist user message images as FilePart so they survive reload`
- `fix(codex): render inbound images as FileParts on user messages`
- `fix(channels): address Copilot review feedback on image-rejection paths`
- `fix(ci): resolve lint errors and wecom-transport coverage gap`
- `fix(ci): handle bun state-dir.ts call in server-dev-script test mock` (#151)

## Test plan
- [ ] CI build passes

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>