### PR TITLE
fix(channels): register /api/channels HTTP routes so web/remote clients can configure channels

### DIFF
--- a/electron/main/app-main.ts
+++ b/electron/main/app-main.ts
@@ -141,6 +141,7 @@ if (!gotTheLock) {
     // Vite middleware will proxy requests to this server
     if (!app.isPackaged) {
       try {
+        authApiServer.setChannelManager(channelManager);
         await authApiServer.start();
       } catch (err) {
         mainLog.error("Failed to start Auth API server:", err);
@@ -149,6 +150,7 @@ if (!gotTheLock) {
       // In production mode, start the production HTTP server
       // This is required for Cloudflare Tunnel to work
       try {
+        productionServer.setChannelManager(channelManager);
         const port = await productionServer.start(WEB_PORT);
         mainLog.info(`Production server started on port ${port}`);
       } catch (err) {

--- a/electron/main/services/auth-api-server.ts
+++ b/electron/main/services/auth-api-server.ts
@@ -6,6 +6,18 @@ import { handleAuthRoutes, handleLogRoutes, handleSettingsRoutes } from "../../.
 import { handleChannelRoutes } from "../../../shared/channel-route-handlers";
 import { AUTH_API_PORT } from "../../../shared/ports";
 
+// Minimal interface so we don't tie this module to the concrete ChannelManager
+// class (avoids circular imports). Matches the shape required by
+// handleChannelRoutes.
+interface ChannelManagerLike {
+  listChannels(): unknown[];
+  getConfig(type: string): unknown | undefined;
+  updateConfig(type: string, updates: Record<string, unknown>): Promise<void>;
+  startChannel(type: string): Promise<void>;
+  stopChannel(type: string): Promise<void>;
+  getStatus(type: string): unknown | undefined;
+}
+
 // ============================================================================
 // Internal Auth API Server
 // This server handles all device/auth related API requests.
@@ -15,6 +27,12 @@ import { AUTH_API_PORT } from "../../../shared/ports";
 
 class AuthApiServer {
   private server: http.Server | null = null;
+  private channelManager: ChannelManagerLike | null = null;
+
+  /** Inject the ChannelManager so /api/channels/* routes work from web clients. */
+  setChannelManager(channelManager: ChannelManagerLike): void {
+    this.channelManager = channelManager;
+  }
 
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
@@ -90,6 +108,19 @@ class AuthApiServer {
       saveSettings,
     });
     if (settingsHandled) return;
+
+    // Channel routes (auth-required) — required for web/remote clients that
+    // can't use Electron IPC.
+    if (this.channelManager) {
+      const channelHandled = await handleChannelRoutes(
+        req,
+        res,
+        pathname,
+        deviceStore,
+        this.channelManager,
+      );
+      if (channelHandled) return;
+    }
 
     // Not found
     sendJson(res, { error: "Not found" }, 404);

--- a/electron/main/services/auth-api-server.ts
+++ b/electron/main/services/auth-api-server.ts
@@ -1,7 +1,7 @@
 import http from "http";
 import { deviceStore } from "./device-store";
 import { authLog, getLogFilePath, getFileLogLevel, setFileLogLevel, loadSettings, saveSettings } from "./logger";
-import { sendJson } from "../../../shared/http-utils";
+import { requireAuth, sendJson } from "../../../shared/http-utils";
 import { handleAuthRoutes, handleLogRoutes, handleSettingsRoutes } from "../../../shared/auth-route-handlers";
 import { handleChannelRoutes, type ChannelManagerRoutes } from "../../../shared/channel-route-handlers";
 import { AUTH_API_PORT } from "../../../shared/ports";
@@ -12,6 +12,8 @@ import { AUTH_API_PORT } from "../../../shared/ports";
 // In development, Vite proxies requests here. In production, Electron handles
 // everything via IPC, so this server is only used in development.
 // ============================================================================
+
+const CHANNEL_SERVICE_UNAVAILABLE_ERROR = "Channel service temporarily unavailable";
 
 class AuthApiServer {
   private server: http.Server | null = null;
@@ -101,9 +103,11 @@ class AuthApiServer {
     // can't use Electron IPC.
     if (pathname === "/api/channels" || pathname.startsWith("/api/channels/")) {
       if (!this.channelManager) {
+        if (!requireAuth(req, res, deviceStore)) return;
+        authLog.warn("ChannelManager not configured; unable to handle channel route:", pathname);
         sendJson(
           res,
-          { error: "ChannelManager not configured on auth-api server" },
+          { error: CHANNEL_SERVICE_UNAVAILABLE_ERROR },
           503,
         );
         return;

--- a/electron/main/services/auth-api-server.ts
+++ b/electron/main/services/auth-api-server.ts
@@ -3,20 +3,8 @@ import { deviceStore } from "./device-store";
 import { authLog, getLogFilePath, getFileLogLevel, setFileLogLevel, loadSettings, saveSettings } from "./logger";
 import { sendJson } from "../../../shared/http-utils";
 import { handleAuthRoutes, handleLogRoutes, handleSettingsRoutes } from "../../../shared/auth-route-handlers";
-import { handleChannelRoutes } from "../../../shared/channel-route-handlers";
+import { handleChannelRoutes, type ChannelManagerRoutes } from "../../../shared/channel-route-handlers";
 import { AUTH_API_PORT } from "../../../shared/ports";
-
-// Minimal interface so we don't tie this module to the concrete ChannelManager
-// class (avoids circular imports). Matches the shape required by
-// handleChannelRoutes.
-interface ChannelManagerLike {
-  listChannels(): unknown[];
-  getConfig(type: string): unknown | undefined;
-  updateConfig(type: string, updates: Record<string, unknown>): Promise<void>;
-  startChannel(type: string): Promise<void>;
-  stopChannel(type: string): Promise<void>;
-  getStatus(type: string): unknown | undefined;
-}
 
 // ============================================================================
 // Internal Auth API Server
@@ -27,10 +15,10 @@ interface ChannelManagerLike {
 
 class AuthApiServer {
   private server: http.Server | null = null;
-  private channelManager: ChannelManagerLike | null = null;
+  private channelManager: ChannelManagerRoutes | null = null;
 
   /** Inject the ChannelManager so /api/channels/* routes work from web clients. */
-  setChannelManager(channelManager: ChannelManagerLike): void {
+  setChannelManager(channelManager: ChannelManagerRoutes): void {
     this.channelManager = channelManager;
   }
 
@@ -111,7 +99,15 @@ class AuthApiServer {
 
     // Channel routes (auth-required) — required for web/remote clients that
     // can't use Electron IPC.
-    if (this.channelManager) {
+    if (pathname === "/api/channels" || pathname.startsWith("/api/channels/")) {
+      if (!this.channelManager) {
+        sendJson(
+          res,
+          { error: "ChannelManager not configured on auth-api server" },
+          503,
+        );
+        return;
+      }
       const channelHandled = await handleChannelRoutes(
         req,
         res,

--- a/electron/main/services/production-server.ts
+++ b/electron/main/services/production-server.ts
@@ -6,7 +6,7 @@ import { deviceStore } from "./device-store";
 import { prodServerLog, getLogFilePath, getFileLogLevel, setFileLogLevel, loadSettings, saveSettings } from "./logger";
 import { sendJson, getClientIp, isLocalhost, getLocalIp } from "../../../shared/http-utils";
 import { handleAuthRoutes, handleLogRoutes, handleSettingsRoutes } from "../../../shared/auth-route-handlers";
-import { handleChannelRoutes } from "../../../shared/channel-route-handlers";
+import { handleChannelRoutes, type ChannelManagerRoutes } from "../../../shared/channel-route-handlers";
 import { WEB_PORT, OPENCODE_PORT, WEBHOOK_PORT } from "../../../shared/ports";
 
 // ============================================================================
@@ -146,23 +146,14 @@ function proxyToWebhook(
   });
 }
 
-interface ChannelManagerLike {
-  listChannels(): unknown[];
-  getConfig(type: string): unknown | undefined;
-  updateConfig(type: string, updates: Record<string, unknown>): Promise<void>;
-  startChannel(type: string): Promise<void>;
-  stopChannel(type: string): Promise<void>;
-  getStatus(type: string): unknown | undefined;
-}
-
 class ProductionServer {
   private server: http.Server | null = null;
   private port: number = WEB_PORT;
   private staticRoot: string = "";
-  private channelManager: ChannelManagerLike | null = null;
+  private channelManager: ChannelManagerRoutes | null = null;
 
   /** Inject the ChannelManager so /api/channels/* routes work from web clients. */
-  setChannelManager(channelManager: ChannelManagerLike): void {
+  setChannelManager(channelManager: ChannelManagerRoutes): void {
     this.channelManager = channelManager;
   }
 
@@ -328,16 +319,22 @@ class ProductionServer {
     // that can't use Electron IPC.
     // ========================================================================
     if (pathname === "/api/channels" || pathname.startsWith("/api/channels/")) {
-      if (this.channelManager) {
-        const handled = await handleChannelRoutes(
-          req,
+      if (!this.channelManager) {
+        sendJson(
           res,
-          pathname,
-          deviceStore,
-          this.channelManager,
+          { error: "ChannelManager not configured on production server" },
+          503,
         );
-        if (handled) return;
+        return;
       }
+      const handled = await handleChannelRoutes(
+        req,
+        res,
+        pathname,
+        deviceStore,
+        this.channelManager,
+      );
+      if (handled) return;
       sendJson(res, { error: "Not found" }, 404);
       return;
     }

--- a/electron/main/services/production-server.ts
+++ b/electron/main/services/production-server.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { app } from "electron";
 import { deviceStore } from "./device-store";
 import { prodServerLog, getLogFilePath, getFileLogLevel, setFileLogLevel, loadSettings, saveSettings } from "./logger";
-import { sendJson, getClientIp, isLocalhost, getLocalIp } from "../../../shared/http-utils";
+import { sendJson, requireAuth, getClientIp, isLocalhost, getLocalIp } from "../../../shared/http-utils";
 import { handleAuthRoutes, handleLogRoutes, handleSettingsRoutes } from "../../../shared/auth-route-handlers";
 import { handleChannelRoutes, type ChannelManagerRoutes } from "../../../shared/channel-route-handlers";
 import { WEB_PORT, OPENCODE_PORT, WEBHOOK_PORT } from "../../../shared/ports";
@@ -14,6 +14,8 @@ import { WEB_PORT, OPENCODE_PORT, WEBHOOK_PORT } from "../../../shared/ports";
 // Serves static files and proxies API requests when running in packaged mode.
 // This is required for Cloudflare Tunnel to work - it needs an HTTP server.
 // ============================================================================
+
+const CHANNEL_SERVICE_UNAVAILABLE_ERROR = "Channel service temporarily unavailable";
 
 // MIME types for static file serving
 const MIME_TYPES: Record<string, string> = {
@@ -320,9 +322,11 @@ class ProductionServer {
     // ========================================================================
     if (pathname === "/api/channels" || pathname.startsWith("/api/channels/")) {
       if (!this.channelManager) {
+        if (!requireAuth(req, res, deviceStore)) return;
+        prodServerLog.warn("ChannelManager not configured; unable to handle channel route:", pathname);
         sendJson(
           res,
-          { error: "ChannelManager not configured on production server" },
+          { error: CHANNEL_SERVICE_UNAVAILABLE_ERROR },
           503,
         );
         return;

--- a/electron/main/services/production-server.ts
+++ b/electron/main/services/production-server.ts
@@ -146,10 +146,25 @@ function proxyToWebhook(
   });
 }
 
+interface ChannelManagerLike {
+  listChannels(): unknown[];
+  getConfig(type: string): unknown | undefined;
+  updateConfig(type: string, updates: Record<string, unknown>): Promise<void>;
+  startChannel(type: string): Promise<void>;
+  stopChannel(type: string): Promise<void>;
+  getStatus(type: string): unknown | undefined;
+}
+
 class ProductionServer {
   private server: http.Server | null = null;
   private port: number = WEB_PORT;
   private staticRoot: string = "";
+  private channelManager: ChannelManagerLike | null = null;
+
+  /** Inject the ChannelManager so /api/channels/* routes work from web clients. */
+  setChannelManager(channelManager: ChannelManagerLike): void {
+    this.channelManager = channelManager;
+  }
 
   getPort(): number {
     return this.port;
@@ -305,6 +320,25 @@ class ProductionServer {
     // ========================================================================
     if (pathname === "/api/messages" || pathname.startsWith("/webhook/")) {
       proxyToWebhook(req, res, pathname + url.search);
+      return;
+    }
+
+    // ========================================================================
+    // Channel API Routes (auth-required) — required for web/remote clients
+    // that can't use Electron IPC.
+    // ========================================================================
+    if (pathname === "/api/channels" || pathname.startsWith("/api/channels/")) {
+      if (this.channelManager) {
+        const handled = await handleChannelRoutes(
+          req,
+          res,
+          pathname,
+          deviceStore,
+          this.channelManager,
+        );
+        if (handled) return;
+      }
+      sendJson(res, { error: "Not found" }, 404);
       return;
     }
 

--- a/shared/channel-route-handlers.ts
+++ b/shared/channel-route-handlers.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "http";
 import { parseBody, sendJson, requireAuth } from "./http-utils";
 
-interface ChannelManagerRoutes {
+export interface ChannelManagerRoutes {
   listChannels(): unknown[];
   getConfig(type: string): unknown | undefined;
   updateConfig(type: string, updates: Record<string, unknown>): Promise<void>;

--- a/src/components/ChannelConfigModal.tsx
+++ b/src/components/ChannelConfigModal.tsx
@@ -55,7 +55,7 @@ export function ChannelConfigModal(props: ChannelConfigModalProps) {
       props.onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      setSaveError(message || "Save failed");
+      setSaveError(message || t().channel.saveFailed);
     } finally {
       setSaving(false);
     }

--- a/src/components/ChannelConfigModal.tsx
+++ b/src/components/ChannelConfigModal.tsx
@@ -26,10 +26,12 @@ export function ChannelConfigModal(props: ChannelConfigModalProps) {
   const { t } = useI18n();
   const [config, setConfig] = createSignal<Record<string, unknown>>({ ...props.initialConfig });
   const [saving, setSaving] = createSignal(false);
+  const [saveError, setSaveError] = createSignal<string | null>(null);
 
   createEffect(() => {
     if (props.isOpen) {
       setConfig({ ...props.initialConfig });
+      setSaveError(null);
     }
   });
 
@@ -47,11 +49,13 @@ export function ChannelConfigModal(props: ChannelConfigModalProps) {
 
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       await props.onSave(config());
       props.onClose();
-    } catch {
-      // Error handled by parent
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setSaveError(message || "Save failed");
     } finally {
       setSaving(false);
     }
@@ -171,6 +175,12 @@ export function ChannelConfigModal(props: ChannelConfigModalProps) {
               <p class="text-xs text-gray-400 dark:text-gray-500">
                 {t().channel.configRequired}
               </p>
+            </Show>
+
+            <Show when={saveError()}>
+              <div class="rounded-lg border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/20 p-3">
+                <p class="text-xs text-red-700 dark:text-red-300 break-words">{saveError()}</p>
+              </div>
             </Show>
           </div>
 

--- a/src/components/FeishuConfigModal.tsx
+++ b/src/components/FeishuConfigModal.tsx
@@ -46,7 +46,7 @@ export function FeishuConfigModal(props: FeishuConfigModalProps) {
       props.onClose();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      setSaveError(message || "Save failed");
+      setSaveError(message || t().channel.saveFailed);
     } finally {
       setSaving(false);
     }

--- a/src/components/FeishuConfigModal.tsx
+++ b/src/components/FeishuConfigModal.tsx
@@ -22,6 +22,7 @@ export function FeishuConfigModal(props: FeishuConfigModalProps) {
   const { t } = useI18n();
   const [config, setConfig] = createSignal<FeishuConfig>({ ...props.initialConfig });
   const [saving, setSaving] = createSignal(false);
+  const [saveError, setSaveError] = createSignal<string | null>(null);
 
   const isSecretSatisfied = (key: string) => {
     const val = config()[key as keyof FeishuConfig];
@@ -33,16 +34,19 @@ export function FeishuConfigModal(props: FeishuConfigModalProps) {
   createEffect(() => {
     if (props.isOpen) {
       setConfig({ ...props.initialConfig });
+      setSaveError(null);
     }
   });
 
   const handleSave = async () => {
     setSaving(true);
+    setSaveError(null);
     try {
       await props.onSave(config());
       props.onClose();
-    } catch {
-      // Error handled by parent
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      setSaveError(message || "Save failed");
     } finally {
       setSaving(false);
     }
@@ -165,6 +169,13 @@ export function FeishuConfigModal(props: FeishuConfigModalProps) {
               <p class="text-xs text-gray-400 dark:text-gray-500">
                 {t().channel.configRequired}
               </p>
+            </Show>
+
+            {/* Save error */}
+            <Show when={saveError()}>
+              <div class="rounded-lg border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/20 p-3">
+                <p class="text-xs text-red-700 dark:text-red-300 break-words">{saveError()}</p>
+              </div>
             </Show>
           </div>
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -490,6 +490,7 @@ export interface LocaleDict {
     secretConfiguredHint: string;
     save: string;
     saving: string;
+    saveFailed: string;
     directConnect: string;
     directConnectBadge: string;
     webhookConnect: string;
@@ -1190,6 +1191,7 @@ export const en: LocaleDict = {
     secretConfiguredHint: "Configured — leave empty to keep current",
     save: "Save",
     saving: "Saving...",
+    saveFailed: "Save failed",
     directConnect: "Direct",
     directConnectBadge: "Outbound",
     webhookConnect: "Requires Public Access",

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -487,6 +487,7 @@ export const ru: LocaleDict = {
     secretConfiguredHint: "Настроено — оставьте пустым, чтобы сохранить текущее значение",
     save: "Сохранить",
     saving: "Сохранение...",
+    saveFailed: "Не удалось сохранить",
     directConnect: "Прямое подключение",
     directConnectBadge: "Исходящее соединение",
     webhookConnect: "Требуется публичный доступ",

--- a/src/locales/zh.ts
+++ b/src/locales/zh.ts
@@ -484,6 +484,7 @@ export const zh: LocaleDict = {
     secretConfiguredHint: "已配置 — 留空保持不变",
     save: "保存",
     saving: "保存中...",
+    saveFailed: "保存失败",
     directConnect: "直连",
     directConnectBadge: "出站连接",
     webhookConnect: "需要公网访问",

--- a/tests/unit/electron/services/auth-api-server.test.ts
+++ b/tests/unit/electron/services/auth-api-server.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("electron-log/main", () => {
+  const mockScope = () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+  });
+  const mockLog: any = {
+    transports: {
+      file: {
+        resolvePathFn: null,
+        maxSize: 0,
+        level: "warn",
+        format: "",
+        getFile: vi.fn(() => ({ path: "/tmp/test.log" })),
+      },
+      console: { level: "info", format: "" },
+    },
+    errorHandler: { startCatching: vi.fn() },
+    eventLogger: { startLogging: vi.fn() },
+    scope: vi.fn(() => mockScope()),
+  };
+  return { default: mockLog };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+    getPath: vi.fn((name: string) => (name === "logs" ? "/tmp/logs" : "/tmp/userData")),
+  },
+}));
+
+// Avoid the real device store binding to disk. The auth-api-server uses
+// `deviceStore` only as a TokenVerifier; we override verifyToken per-test.
+vi.mock("../../../../electron/main/services/device-store", () => ({
+  deviceStore: {
+    verifyToken: vi.fn(() => ({ valid: false })),
+  },
+}));
+
+// Force AUTH_API_PORT to 0 so the OS picks a free ephemeral port and the
+// test never collides with a real codemux dev instance.
+vi.mock("../../../../shared/ports", async () => {
+  const actual = await vi.importActual<typeof import("../../../../shared/ports")>(
+    "../../../../shared/ports",
+  );
+  return { ...actual, AUTH_API_PORT: 0 };
+});
+
+// ---------------------------------------------------------------------------
+// Imports (must come after vi.mock calls)
+// ---------------------------------------------------------------------------
+
+import { authApiServer } from "../../../../electron/main/services/auth-api-server";
+import { deviceStore } from "../../../../electron/main/services/device-store";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Json = { status: number; body: any };
+
+function request(port: number, path: string, init: { method?: string; headers?: Record<string, string>; body?: string } = {}): Promise<Json> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: init.method ?? "GET",
+        headers: init.headers ?? {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf-8");
+          let body: any = text;
+          try {
+            body = text ? JSON.parse(text) : undefined;
+          } catch {
+            // leave as text
+          }
+          resolve({ status: res.statusCode ?? 0, body });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (init.body) req.write(init.body);
+    req.end();
+  });
+}
+
+function makeChannelManager() {
+  return {
+    listChannels: vi.fn(() => [{ type: "feishu", name: "feishu", status: "running" }]),
+    getConfig: vi.fn(() => ({ type: "feishu", enabled: true, options: { appId: "abc" } })),
+    updateConfig: vi.fn(async () => undefined),
+    startChannel: vi.fn(async () => undefined),
+    stopChannel: vi.fn(async () => undefined),
+    getStatus: vi.fn(() => ({ type: "feishu", name: "feishu", status: "running" })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AuthApiServer", () => {
+  let port: number;
+
+  beforeAll(async () => {
+    await authApiServer.start();
+    // Access the underlying http.Server to discover the OS-assigned port.
+    const internalServer = (authApiServer as unknown as { server: http.Server }).server;
+    port = (internalServer.address() as AddressInfo).port;
+    expect(port).toBeGreaterThan(0);
+  });
+
+  afterAll(async () => {
+    await authApiServer.stop();
+  });
+
+  describe("setChannelManager + /api/channels/* dispatch", () => {
+    it("returns 503 when /api/channels is requested before the manager is injected", async () => {
+      // Ensure no manager is attached
+      (authApiServer as unknown as { channelManager: unknown }).channelManager = null;
+
+      const res = await request(port, "/api/channels");
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+    });
+
+    it("returns 503 for nested /api/channels/<type>/start paths when manager missing", async () => {
+      (authApiServer as unknown as { channelManager: unknown }).channelManager = null;
+
+      const res = await request(port, "/api/channels/feishu/start", { method: "POST" });
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+    });
+
+    it("delegates to handleChannelRoutes when manager is injected (lists channels with valid auth)", async () => {
+      const cm = makeChannelManager();
+      authApiServer.setChannelManager(cm);
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const res = await request(port, "/api/channels", {
+        headers: { authorization: "Bearer good-token" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(cm.listChannels).toHaveBeenCalledTimes(1);
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body[0]).toMatchObject({ type: "feishu" });
+    });
+
+    it("returns 401 from handleChannelRoutes when caller is unauthenticated", async () => {
+      const cm = makeChannelManager();
+      authApiServer.setChannelManager(cm);
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValue({ valid: false });
+
+      const res = await request(port, "/api/channels");
+      expect(res.status).toBe(401);
+      expect(cm.listChannels).not.toHaveBeenCalled();
+    });
+
+    it("forwards a successful PUT update to channelManager.updateConfig", async () => {
+      const cm = makeChannelManager();
+      authApiServer.setChannelManager(cm);
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const body = JSON.stringify({ options: { appId: "new-id" } });
+      const res = await request(port, "/api/channels/feishu", {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer good-token",
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body)),
+        },
+        body,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true });
+      expect(cm.updateConfig).toHaveBeenCalledWith("feishu", {
+        options: { appId: "new-id" },
+      });
+    });
+  });
+
+  describe("non-channel routes", () => {
+    it("returns 204 for CORS preflight (OPTIONS)", async () => {
+      const res = await request(port, "/api/anything", { method: "OPTIONS" });
+      // sendJson default for OPTIONS preflight => 200 with {} body in this server
+      // (see handleRequest); accept either 200 or 204 to stay robust.
+      expect([200, 204]).toContain(res.status);
+    });
+
+    it("returns 404 for unknown paths", async () => {
+      const res = await request(port, "/api/no-such-thing");
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Not found");
+    });
+  });
+
+  describe("getPort()", () => {
+    it("returns the configured AUTH_API_PORT constant (mocked to 0 in this suite)", () => {
+      expect(authApiServer.getPort()).toBe(0);
+    });
+  });
+});

--- a/tests/unit/electron/services/auth-api-server.test.ts
+++ b/tests/unit/electron/services/auth-api-server.test.ts
@@ -131,21 +131,42 @@ describe("AuthApiServer", () => {
   });
 
   describe("setChannelManager + /api/channels/* dispatch", () => {
-    it("returns 503 when /api/channels is requested before the manager is injected", async () => {
+    it("returns 401 when /api/channels is requested before the manager is injected by an unauthenticated caller", async () => {
       // Ensure no manager is attached
       (authApiServer as unknown as { channelManager: unknown }).channelManager = null;
 
       const res = await request(port, "/api/channels");
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns a generic 503 when /api/channels is requested before the manager is injected", async () => {
+      (authApiServer as unknown as { channelManager: unknown }).channelManager = null;
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const res = await request(port, "/api/channels", {
+        headers: { authorization: "Bearer good-token" },
+      });
       expect(res.status).toBe(503);
-      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+      expect(res.body.error).toBe("Channel service temporarily unavailable");
     });
 
     it("returns 503 for nested /api/channels/<type>/start paths when manager missing", async () => {
       (authApiServer as unknown as { channelManager: unknown }).channelManager = null;
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
 
-      const res = await request(port, "/api/channels/feishu/start", { method: "POST" });
+      const res = await request(port, "/api/channels/feishu/start", {
+        method: "POST",
+        headers: { authorization: "Bearer good-token" },
+      });
       expect(res.status).toBe(503);
-      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+      expect(res.body.error).toBe("Channel service temporarily unavailable");
     });
 
     it("delegates to handleChannelRoutes when manager is injected (lists channels with valid auth)", async () => {

--- a/tests/unit/electron/services/production-server.test.ts
+++ b/tests/unit/electron/services/production-server.test.ts
@@ -233,20 +233,41 @@ describe("ProductionServer", () => {
   });
 
   describe("setChannelManager + /api/channels/* dispatch", () => {
-    it("returns 503 when /api/channels is requested before the manager is injected", async () => {
+    it("returns 401 when /api/channels is requested before the manager is injected by an unauthenticated caller", async () => {
       (productionServer as unknown as { channelManager: unknown }).channelManager = null;
 
       const res = await request(port, "/api/channels");
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns a generic 503 when /api/channels is requested before the manager is injected", async () => {
+      (productionServer as unknown as { channelManager: unknown }).channelManager = null;
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const res = await request(port, "/api/channels", {
+        headers: { authorization: "Bearer good-token" },
+      });
       expect(res.status).toBe(503);
-      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+      expect(res.body.error).toBe("Channel service temporarily unavailable");
     });
 
     it("returns 503 for nested /api/channels/<type>/start when manager missing", async () => {
       (productionServer as unknown as { channelManager: unknown }).channelManager = null;
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
 
-      const res = await request(port, "/api/channels/feishu/start", { method: "POST" });
+      const res = await request(port, "/api/channels/feishu/start", {
+        method: "POST",
+        headers: { authorization: "Bearer good-token" },
+      });
       expect(res.status).toBe(503);
-      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+      expect(res.body.error).toBe("Channel service temporarily unavailable");
     });
 
     it("delegates to handleChannelRoutes when manager is injected", async () => {

--- a/tests/unit/electron/services/production-server.test.ts
+++ b/tests/unit/electron/services/production-server.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("electron-log/main", () => {
+  const mockScope = () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    verbose: vi.fn(),
+  });
+  const mockLog: any = {
+    transports: {
+      file: {
+        resolvePathFn: null,
+        maxSize: 0,
+        level: "warn",
+        format: "",
+        getFile: vi.fn(() => ({ path: "/tmp/test.log" })),
+      },
+      console: { level: "info", format: "" },
+    },
+    errorHandler: { startCatching: vi.fn() },
+    eventLogger: { startLogging: vi.fn() },
+    scope: vi.fn(() => mockScope()),
+  };
+  return { default: mockLog };
+});
+
+vi.mock("electron", () => ({
+  app: {
+    isPackaged: false,
+    getAppPath: vi.fn(() => "/tmp/nonexistent-app-root"),
+    getPath: vi.fn((name: string) => (name === "logs" ? "/tmp/logs" : "/tmp/userData")),
+  },
+}));
+
+vi.mock("../../../../electron/main/services/device-store", () => ({
+  deviceStore: {
+    verifyToken: vi.fn(() => ({ valid: false })),
+  },
+}));
+
+// Point the proxy targets at ports that are guaranteed to be closed so the
+// fall-back branches in proxyToOpenCode/proxyToWebhook are exercised
+// deterministically (otherwise a local OpenCode instance on the default port
+// would answer and skew the test).
+vi.mock("../../../../shared/ports", async () => {
+  const actual = await vi.importActual<typeof import("../../../../shared/ports")>(
+    "../../../../shared/ports",
+  );
+  return {
+    ...actual,
+    OPENCODE_PORT: 1, // privileged port, will refuse from userland
+    WEBHOOK_PORT: 1,
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Imports (must come after vi.mock calls)
+// ---------------------------------------------------------------------------
+
+import { productionServer } from "../../../../electron/main/services/production-server";
+import { deviceStore } from "../../../../electron/main/services/device-store";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Json = { status: number; headers: http.IncomingHttpHeaders; body: any };
+
+function request(
+  port: number,
+  path: string,
+  init: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<Json> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: init.method ?? "GET",
+        headers: init.headers ?? {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf-8");
+          let body: any = text;
+          try {
+            body = text ? JSON.parse(text) : undefined;
+          } catch {
+            // leave as text
+          }
+          resolve({
+            status: res.statusCode ?? 0,
+            headers: res.headers,
+            body,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    if (init.body) req.write(init.body);
+    req.end();
+  });
+}
+
+function makeChannelManager() {
+  return {
+    listChannels: vi.fn(() => [{ type: "feishu", name: "feishu", status: "stopped" }]),
+    getConfig: vi.fn(() => ({ type: "feishu", enabled: false, options: { appId: "abc" } })),
+    updateConfig: vi.fn(async () => undefined),
+    startChannel: vi.fn(async () => undefined),
+    stopChannel: vi.fn(async () => undefined),
+    getStatus: vi.fn(() => ({ type: "feishu", name: "feishu", status: "stopped" })),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ProductionServer", () => {
+  let port: number;
+
+  beforeAll(async () => {
+    // port 0 → OS picks a free ephemeral port. start() resolves with the
+    // value held in `this.port` (which stays 0 for OS-assigned listens), so
+    // we read the actual port from the underlying http.Server.
+    await productionServer.start(0);
+    const internalServer = productionServer.getServer();
+    expect(internalServer).not.toBeNull();
+    port = (internalServer!.address() as AddressInfo).port;
+    expect(port).toBeGreaterThan(0);
+  });
+
+  afterAll(async () => {
+    await productionServer.stop();
+  });
+
+  describe("lifecycle", () => {
+    it("isRunning() returns true while server is bound, false after stop", () => {
+      expect(productionServer.isRunning()).toBe(true);
+      expect(productionServer.getServer()).not.toBeNull();
+    });
+
+    it("getPort() returns the value passed to start() (0 here, OS-assigned)", () => {
+      expect(productionServer.getPort()).toBe(0);
+    });
+
+    it("start() is a no-op if called again while already running", async () => {
+      const samePort = await productionServer.start(0);
+      expect(samePort).toBe(0);
+    });
+  });
+
+  describe("CORS preflight", () => {
+    it("OPTIONS returns 204 with permissive CORS headers", async () => {
+      const res = await request(port, "/api/anything", { method: "OPTIONS" });
+      expect(res.status).toBe(204);
+      expect(res.headers["access-control-allow-origin"]).toBe("*");
+      expect(res.headers["access-control-allow-methods"]).toMatch(/POST/);
+      expect(res.headers["access-control-allow-headers"]).toMatch(/authorization/i);
+    });
+  });
+
+  describe("System routes", () => {
+    it("GET /api/system/info returns the local IP and the configured port", async () => {
+      const res = await request(port, "/api/system/info");
+      expect(res.status).toBe(200);
+      // server.port stored from start(0) → API echoes 0 even though the
+      // OS-assigned ephemeral port is what we actually connected on.
+      expect(res.body.port).toBe(0);
+      expect(typeof res.body.localIp).toBe("string");
+    });
+
+    it("GET /api/system/is-local returns isLocal=true for 127.0.0.1 calls", async () => {
+      const res = await request(port, "/api/system/is-local");
+      expect(res.status).toBe(200);
+      expect(res.body.isLocal).toBe(true);
+    });
+
+    it("GET /api/tunnel/anything returns 400 (IPC-only)", async () => {
+      const res = await request(port, "/api/tunnel/start");
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/IPC/);
+    });
+  });
+
+  describe("Auth/Settings route fall-through", () => {
+    it("returns 404 for an unknown /api/auth path", async () => {
+      const res = await request(port, "/api/auth/not-a-real-route");
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Not found");
+    });
+
+    it("returns 401 for an unauthenticated /api/settings/shared request (auth-required)", async () => {
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValue({ valid: false });
+      const res = await request(port, "/api/settings/shared");
+      // No bearer token → requireAuth sends 401
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("Proxy fall-back when upstreams are down", () => {
+    it("GET /opencode-api/health returns 503 when OpenCode is not running", async () => {
+      const res = await request(port, "/opencode-api/health");
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/OpenCode/i);
+    });
+
+    it("POST /api/messages returns 503 when WebhookServer is not running", async () => {
+      const body = JSON.stringify({ hello: "world" });
+      const res = await request(port, "/api/messages", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body)),
+        },
+        body,
+      });
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/Webhook/i);
+    });
+  });
+
+  describe("setChannelManager + /api/channels/* dispatch", () => {
+    it("returns 503 when /api/channels is requested before the manager is injected", async () => {
+      (productionServer as unknown as { channelManager: unknown }).channelManager = null;
+
+      const res = await request(port, "/api/channels");
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+    });
+
+    it("returns 503 for nested /api/channels/<type>/start when manager missing", async () => {
+      (productionServer as unknown as { channelManager: unknown }).channelManager = null;
+
+      const res = await request(port, "/api/channels/feishu/start", { method: "POST" });
+      expect(res.status).toBe(503);
+      expect(res.body.error).toMatch(/ChannelManager not configured/i);
+    });
+
+    it("delegates to handleChannelRoutes when manager is injected", async () => {
+      const cm = makeChannelManager();
+      productionServer.setChannelManager(cm);
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const res = await request(port, "/api/channels", {
+        headers: { authorization: "Bearer good-token" },
+      });
+
+      expect(res.status).toBe(200);
+      expect(cm.listChannels).toHaveBeenCalledTimes(1);
+      expect(res.body[0]).toMatchObject({ type: "feishu" });
+    });
+
+    it("forwards a successful PUT update to channelManager.updateConfig", async () => {
+      const cm = makeChannelManager();
+      productionServer.setChannelManager(cm);
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const body = JSON.stringify({ options: { appId: "new-id" } });
+      const res = await request(port, "/api/channels/feishu", {
+        method: "PUT",
+        headers: {
+          authorization: "Bearer good-token",
+          "content-type": "application/json",
+          "content-length": String(Buffer.byteLength(body)),
+        },
+        body,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ success: true });
+      expect(cm.updateConfig).toHaveBeenCalledWith("feishu", {
+        options: { appId: "new-id" },
+      });
+    });
+
+    it("falls through to 404 when no handleChannelRoutes branch matches the verb", async () => {
+      const cm = makeChannelManager();
+      productionServer.setChannelManager(cm);
+      (deviceStore.verifyToken as ReturnType<typeof vi.fn>).mockReturnValue({
+        valid: true,
+        deviceId: "dev-1",
+      });
+
+      const res = await request(port, "/api/channels", {
+        method: "DELETE",
+        headers: { authorization: "Bearer good-token" },
+      });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe("Not found");
+    });
+  });
+
+  describe("Static file serving", () => {
+    it("falls through to 404 for a request that misses all routes (no static root present)", async () => {
+      // staticRoot is /tmp/nonexistent-app-root/out/renderer which doesn't
+      // exist; serveStaticFile catches the stat error and tries index.html,
+      // which also doesn't exist → readFile fails → 404 "Not Found".
+      const res = await request(port, "/some/spa/route");
+      expect(res.status).toBe(404);
+      expect(res.body).toBe("Not Found");
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When CodeMux is accessed via browser/remote (Cloudflare Tunnel, Vite proxy, etc.), configuring any channel (Feishu/Lark, DingTalk, Telegram, Teams, WeCom, …) silently fails — the modal Save button does nothing, no success, no error.

Root cause: both `electron/main/services/auth-api-server.ts` and `electron/main/services/production-server.ts` `import { handleChannelRoutes }` but **never invoke it**. As a result every `/api/channels/*` request falls through to a 404 `{"error": "Not found"}` (or to the SPA static fallback in prod). The frontend modals (`FeishuConfigModal`, `ChannelConfigModal`) then catch the error with an empty `catch {}` and silently swallow it — hence the "nothing happens" UX.

Electron desktop users are unaffected because they go through IPC directly to `ChannelManager`. This affects only web/remote clients.

Regression introduced in #76 (`feat: server mode and web-based channel/settings management`) — the imports were added but the dispatch wiring was forgotten.

Evidence from a real session log:
```
[renderer] [ChannelManagement] Failed to load feishu: Error: Not found
    at browserAuthedRequest (.../src/lib/electron-api.ts)
```

## Fix

- **`auth-api-server.ts` + `production-server.ts`**: dispatch `/api/channels/*` to `handleChannelRoutes`. Each server now exposes a `setChannelManager()` injector so we don't need to import the concrete `ChannelManager` (which would create a circular import with `app-main.ts`). The injected object is typed as a minimal `ChannelManagerLike` interface matching what `handleChannelRoutes` already needs.
- **`app-main.ts`**: call `setChannelManager(channelManager)` on whichever HTTP server is started (dev = auth-api-server, prod = production-server) before `listen`.
- **`FeishuConfigModal.tsx` + `ChannelConfigModal.tsx`**: replace the empty `catch {}` with an inline error banner so that any future API failure is visible to the user instead of being silently swallowed.

## Verification

- `npm run typecheck` — clean
- `bun run test:unit` — 93 files / 3435 tests pass
- Manual: existing IPC path (Electron desktop) unchanged; new HTTP path delegates to the same `channelManager` used by IPC, so reads/writes stay in sync.

## Scope

- Production server flow (packaged + Cloudflare Tunnel): fixed
- Dev server flow (Vite proxy → `auth-api-server` at :4097): fixed
- Electron IPC path: unchanged
- No new dependencies, no schema changes, no migration needed

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>