### PR TITLE
fix(copilot): upgrade copilot-sdk to 1.0.0 and restore skill discovery

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "codemux",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.137",
-        "@github/copilot-sdk": "^1.0.0-beta.3",
+        "@github/copilot-sdk": "1.0.0",
         "@larksuiteoapi/node-sdk": "^1.42.0",
         "@opencode-ai/sdk": "^1.14.41",
         "@parcel/watcher": "^2.5.1",
@@ -223,21 +223,25 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
 
-    "@github/copilot": ["@github/copilot@1.0.44", "", { "optionalDependencies": { "@github/copilot-darwin-arm64": "1.0.44", "@github/copilot-darwin-x64": "1.0.44", "@github/copilot-linux-arm64": "1.0.44", "@github/copilot-linux-x64": "1.0.44", "@github/copilot-win32-arm64": "1.0.44", "@github/copilot-win32-x64": "1.0.44" }, "bin": { "copilot": "npm-loader.js" } }, "sha512-wr/GmNOUaJK/giJK5abyB1oTpEowgFKLi+NJnlyAymKiK/GKCaRlJqiX23H2RetM8vD2hDYUFUFm9lTCooGy0g=="],
+    "@github/copilot": ["@github/copilot@1.0.59", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@github/copilot-darwin-arm64": "1.0.59", "@github/copilot-darwin-x64": "1.0.59", "@github/copilot-linux-arm64": "1.0.59", "@github/copilot-linux-x64": "1.0.59", "@github/copilot-linuxmusl-arm64": "1.0.59", "@github/copilot-linuxmusl-x64": "1.0.59", "@github/copilot-win32-arm64": "1.0.59", "@github/copilot-win32-x64": "1.0.59" }, "bin": { "copilot": "npm-loader.js" } }, "sha512-D8ctn5cwDwYW0drjFhjLeKpEO4cB8G2tQCMfql2BuFsq5n26liLHymw+4JAhmbDxWgD/gEjr6c3u2zVwD0xxzA=="],
 
-    "@github/copilot-darwin-arm64": ["@github/copilot-darwin-arm64@1.0.44", "", { "os": "darwin", "cpu": "arm64", "bin": { "copilot-darwin-arm64": "copilot" } }, "sha512-9NqA5sT2spmNsehxhs51GhXRZIZga5nq+WcMl4LG2QrUPJRDwvHf1bDKqETJUBbYvBY8jONGuTKMRofkMI68YQ=="],
+    "@github/copilot-darwin-arm64": ["@github/copilot-darwin-arm64@1.0.59", "", { "os": "darwin", "cpu": "arm64", "bin": { "copilot-darwin-arm64": "copilot" } }, "sha512-zNbsKhCxzI7HhfUltEoCP43NzZacPQYd41ylixV3iZeO/Tximjkb4KnChH7UYdksDVtdKZGU3BIs+T3hGd9LEw=="],
 
-    "@github/copilot-darwin-x64": ["@github/copilot-darwin-x64@1.0.44", "", { "os": "darwin", "cpu": "x64", "bin": { "copilot-darwin-x64": "copilot" } }, "sha512-QPD8KtXx07SIKILGBl4JDhPyL2Qo0FMmaTYVxR6nkyHkHnFPsUZD6VWGR+T/KMLkcUXFM85Xc1ba9Y27s4nRrQ=="],
+    "@github/copilot-darwin-x64": ["@github/copilot-darwin-x64@1.0.59", "", { "os": "darwin", "cpu": "x64", "bin": { "copilot-darwin-x64": "copilot" } }, "sha512-7LsC02bE5nPzPGNr11+ZospnpW7AeHSfzaFlJ9tipMxo9hAoKPJl4vSr7PtDzTsVMukKnT4Ro9ACPisnbkVS/Q=="],
 
-    "@github/copilot-linux-arm64": ["@github/copilot-linux-arm64@1.0.44", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linux-arm64": "copilot" } }, "sha512-Z8ScIUP433xS18f68NP9jM9zW320Xzpi2wf7Nig/VyfrwupBy25UTezydQMT0KQHLWTEleHOPcYnASY3HgJXnQ=="],
+    "@github/copilot-linux-arm64": ["@github/copilot-linux-arm64@1.0.59", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linux-arm64": "copilot" } }, "sha512-rsiH+qj8hga6a3vdc7LrJLzMXSJHI6a8b4M3zccXYJeAkWKLm7CLmc9Kybtn72qaDTLNLxv+kvQfZ3qLTzFBlA=="],
 
-    "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.44", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-KUl6lvJt0HNKaXSx0T0bIWJ3rvrGwgZYMlkDfqMbuMnZatEQJbjPwxmL/IDfp/c0DyKd7K+ajl17wHYcN/hJIQ=="],
+    "@github/copilot-linux-x64": ["@github/copilot-linux-x64@1.0.59", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linux-x64": "copilot" } }, "sha512-yxthVdw5Fi4KwuduuJBxuSd7ofDVApaaU5KN97lLMQVklxBaP03/xssu2KEuiavIFD4koSTlUGuueIx0L/i8MQ=="],
 
-    "@github/copilot-sdk": ["@github/copilot-sdk@1.0.0-beta.3", "", { "dependencies": { "@github/copilot": "^1.0.44-2", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-PxA5+l8ZxKvjeGYJI8TB9sonWsjR189Ptsf8twY45or2tAtAolr7dQH5hDtzj4EaLvHZTWweFaO/UC6qkmP6cg=="],
+    "@github/copilot-linuxmusl-arm64": ["@github/copilot-linuxmusl-arm64@1.0.59", "", { "os": "linux", "cpu": "arm64", "bin": { "copilot-linuxmusl-arm64": "copilot" } }, "sha512-TxcPcHfhj5+bMqUCjuxSPb7hGNnZt8xmRQgQaBaW89/pnsqVvnJfoI/2sE52btbPMp8M1iase9/Uf9na393AXw=="],
 
-    "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.44", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-JVJxZJwAc95ZfapgOXjNFwSqrWlvC3heo128L+CDkdZ6lwpD1dTGMHT/6rMMEeo3xjZmMm8tiynfwsHLDgTtvQ=="],
+    "@github/copilot-linuxmusl-x64": ["@github/copilot-linuxmusl-x64@1.0.59", "", { "os": "linux", "cpu": "x64", "bin": { "copilot-linuxmusl-x64": "copilot" } }, "sha512-ml3B/3LqU+NkCKuQW/2sejAgpWw+LtYzll/VDhwcqkOBckoigALqj7UvJOf/M/+O2lcgcy9fLh5lg7cJ4Up0tg=="],
 
-    "@github/copilot-win32-x64": ["@github/copilot-win32-x64@1.0.44", "", { "os": "win32", "cpu": "x64", "bin": { "copilot-win32-x64": "copilot.exe" } }, "sha512-Yj3KQ/DqwS50PwRtyQITX2mWIVZeJeX+y0faVSMwUUzG1qxmMcme7wimhKOyc4LSV11DpgVB9MSiBw2xys7iww=="],
+    "@github/copilot-sdk": ["@github/copilot-sdk@1.0.0", "", { "dependencies": { "@github/copilot": "^1.0.57", "vscode-jsonrpc": "^8.2.1", "zod": "^4.3.6" } }, "sha512-OKjmJMDM+GB2uHr8UA6O0FNs1Gfw/tkoE5vUNlYmKbydc9Yjf6pvuBdseGjAVvzc6f9HIbB5eZKLUrxbOTw+yA=="],
+
+    "@github/copilot-win32-arm64": ["@github/copilot-win32-arm64@1.0.59", "", { "os": "win32", "cpu": "arm64", "bin": { "copilot-win32-arm64": "copilot.exe" } }, "sha512-1y7d+ncNBf2rvJcC0Loj3baqzh8JhZz0mQkJjQOL674uyEgQhYqTXPNEqqGUp9lX40BfilEs7aqDbtT323aeMg=="],
+
+    "@github/copilot-win32-x64": ["@github/copilot-win32-x64@1.0.59", "", { "os": "win32", "cpu": "x64", "bin": { "copilot-win32-x64": "copilot.exe" } }, "sha512-tjATvZ5+H9iX0mDNjjF7WUGQ300mculzLU6TmzwhyjdlKUYjd9EULpeYre196AbczupLiKQlpt6m67vZjoJRHA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 

--- a/electron/main/engines/copilot/converters.ts
+++ b/electron/main/engines/copilot/converters.ts
@@ -506,8 +506,8 @@ export function sdkModelToUnified(engineType: EngineType, model: ModelInfo): Uni
 }
 
 export function metadataToSession(engineType: EngineType, meta: SessionMetadata): UnifiedSession {
-  const directory = meta.context?.cwd
-    ? meta.context.cwd.replaceAll("\\", "/")
+  const directory = meta.context?.workingDirectory
+    ? meta.context.workingDirectory.replaceAll("\\", "/")
     : homedir().replaceAll("\\", "/");
 
   return {

--- a/electron/main/engines/copilot/index.ts
+++ b/electron/main/engines/copilot/index.ts
@@ -7,7 +7,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 
 import { timeId } from "../../utils/id-gen";
-import { CopilotClient, CopilotSession } from "@github/copilot-sdk";
+import { CopilotClient, CopilotSession, RuntimeConnection } from "@github/copilot-sdk";
 import { isPromptFallbackTitle } from "../../../../src/lib/session-utils";
 import type {
   SessionEvent,
@@ -246,10 +246,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
       const env = buildCopilotSubprocessEnv(this.options?.env);
 
       this.client = new CopilotClient({
-        useStdio: true,
-        autoRestart: true,
-        autoStart: true,
-        cliPath,
+        connection: RuntimeConnection.forStdio({ path: cliPath }),
         env,
       });
 
@@ -390,6 +387,12 @@ export class CopilotSdkAdapter extends EngineAdapter {
       onPermissionRequest: (req, ctx) => this.handlePermissionRequest(req, ctx),
       onUserInputRequest: (req, ctx) => this.handleUserInputRequest(req as any, ctx),
       systemMessage: { mode: "append" as const, content: CODEMUX_IDENTITY_PROMPT },
+      // Enable skill loading from disk (~/.copilot/skills, ~/.agents/skills,
+      // ~/.claude/skills, plus project-level .copilot/skills via discovery).
+      // SDK 1.0 defaults both to false, which would hide all user-installed
+      // skills from the slash command list.
+      enableSkills: true,
+      enableConfigDiscovery: true,
     };
 
     const sdkSession = await this.client!.createSession(config);
@@ -410,13 +413,13 @@ export class CopilotSdkAdapter extends EngineAdapter {
 
     this.emit("session.created", { session });
 
-    // Fetch initial skills/commands for slash command support.
-    // Await the fetch to ensure cachedCommands is populated before
+    // Fetch initial commands (builtins + skills + client) for slash command
+    // support. Await the fetch to ensure cachedCommands is populated before
     // the frontend calls listCommands() shortly after session creation.
     try {
-      await this.fetchSkills(sdkSession);
+      await this.fetchCommands(sdkSession);
     } catch (err) {
-      copilotLog.warn(`Failed to fetch initial skills for session ${sessionId}:`, err);
+      copilotLog.warn(`Failed to fetch initial commands for session ${sessionId}:`, err);
     }
 
     return session;
@@ -473,7 +476,20 @@ export class CopilotSdkAdapter extends EngineAdapter {
   async sendMessage(
     sessionId: string,
     content: MessagePromptContent[],
-    options?: { mode?: string; modelId?: string; reasoningEffort?: ReasoningEffort | null; directory?: string },
+    options?: {
+      mode?: string;
+      modelId?: string;
+      reasoningEffort?: ReasoningEffort | null;
+      directory?: string;
+      /**
+       * Internal flag: when true, skip creating and emitting the user message
+       * for this send. Used by invokeCommand to avoid duplicate user bubbles
+       * when a skill expands into an agent-prompt that is dispatched via
+       * sendMessage but whose original "/cmd args" was already persisted by
+       * engine-manager.
+       */
+      _internalSuppressUserEmit?: boolean;
+    },
   ): Promise<UnifiedMessage> {
     const session = await this.ensureActiveSession(sessionId, options?.directory);
     const now = Date.now();
@@ -615,17 +631,19 @@ export class CopilotSdkAdapter extends EngineAdapter {
 
     // --- Normal path: session is idle ---
 
-    const userMessage = createUserMessage(
-      sessionId,
-      promptText,
-      now,
-      imageContents.map((c) => ({
-        data: (c as { data: string }).data,
-        mimeType: (c as { mimeType?: string }).mimeType ?? "image/png",
-      })),
-    );
-    this.appendMessageToHistory(sessionId, userMessage);
-    this.emit("message.updated", { sessionId, message: userMessage });
+    if (!options?._internalSuppressUserEmit) {
+      const userMessage = createUserMessage(
+        sessionId,
+        promptText,
+        now,
+        imageContents.map((c) => ({
+          data: (c as { data: string }).data,
+          mimeType: (c as { mimeType?: string }).mimeType ?? "image/png",
+        })),
+      );
+      this.appendMessageToHistory(sessionId, userMessage);
+      this.emit("message.updated", { sessionId, message: userMessage });
+    }
 
     const messageId = timeId("msg");
     const buffer: MessageBuffer = {
@@ -724,7 +742,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
 
     try {
       const session = await this.ensureActiveSession(sessionId);
-      const events = await session.getMessages();
+      const events = await session.getEvents();
       const messages = convertEventsToMessages(sessionId, events);
       this.messageHistory.set(sessionId, messages);
       return messages;
@@ -746,7 +764,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
         onPermissionRequest: userNotAvailablePermission,
       };
       session = await this.client!.resumeSession(engineSessionId, config);
-      const events = await session.getMessages();
+      const events = await session.getEvents();
       copilotLog.info(
         `[Copilot] getHistoricalMessages(${engineSessionId}): ${events.length} events`,
       );
@@ -898,31 +916,60 @@ export class CopilotSdkAdapter extends EngineAdapter {
 
   // --- Slash Commands / Skills ---
 
-  private async fetchSkills(session: CopilotSession): Promise<void> {
+  /**
+   * Fetch the full list of slash commands (builtins, skills, client commands)
+   * from the active session and cache them. Falls back to merging
+   * `skills.list()` for any user-installed skill that `commands.list()` may
+   * not have surfaced (e.g. disabled / non-user-invocable).
+   */
+  private async fetchCommands(session: CopilotSession): Promise<void> {
     try {
-      copilotLog.debug(`[Copilot] fetchSkills: calling session.rpc.skills.list()...`);
-      const result = await session.rpc.skills.list();
-      copilotLog.debug(`[Copilot] fetchSkills: received ${Array.isArray((result as any)?.skills ?? result) ? ((result as any)?.skills ?? result).length : 0} skills`);
-      const skills = (result as any)?.skills ?? (result as any) ?? [];
-      if (Array.isArray(skills)) {
-        this.cachedCommands = skills
-          .filter((s: any) => s.userInvocable !== false)
-          .map((s: any) => ({
-            name: s.name,
-            description: s.description ?? "",
-            source: s.source,
-            userInvocable: s.userInvocable,
-          }));
-        copilotLog.info(`[Copilot] fetchSkills: cached ${this.cachedCommands.length} commands: ${this.cachedCommands.map(c => c.name).join(", ")}`);
-        this.emit("commands.changed", {
-          engineType: this.engineType,
-          commands: this.cachedCommands,
-        });
-      } else {
-        copilotLog.warn(`[Copilot] fetchSkills: skills is not an array: ${typeof skills}`);
+      try {
+        await session.rpc.skills.ensureLoaded();
+      } catch (err) {
+        copilotLog.debug(`[Copilot] skills.ensureLoaded failed (continuing):`, err);
       }
+
+      const result = await session.rpc.commands.list({
+        includeBuiltins: true,
+        includeSkills: true,
+        includeClientCommands: true,
+      });
+      const commands = result?.commands ?? [];
+      const merged = new Map<string, EngineCommand>();
+      for (const cmd of commands) {
+        merged.set(cmd.name, {
+          name: cmd.name,
+          description: cmd.description ?? "",
+          argumentHint: cmd.input?.hint,
+        });
+      }
+
+      try {
+        const skillResult = await session.rpc.skills.list();
+        const skills = skillResult?.skills ?? [];
+        for (const skill of skills) {
+          if (skill.source === "builtin") continue;
+          if (merged.has(skill.name)) continue;
+          merged.set(skill.name, {
+            name: skill.name,
+            description: skill.description ?? "",
+          });
+        }
+      } catch (err) {
+        copilotLog.debug(`[Copilot] skills.list fallback failed:`, err);
+      }
+
+      this.cachedCommands = Array.from(merged.values());
+      copilotLog.info(
+        `[Copilot] fetchCommands: cached ${this.cachedCommands.length} commands`,
+      );
+      this.emit("commands.changed", {
+        engineType: this.engineType,
+        commands: this.cachedCommands,
+      });
     } catch (err) {
-      copilotLog.warn(`[Copilot] fetchSkills FAILED:`, err);
+      copilotLog.warn(`[Copilot] fetchCommands FAILED:`, err);
     }
   }
 
@@ -937,13 +984,13 @@ export class CopilotSdkAdapter extends EngineAdapter {
     if (sessionId) {
       let session = this.activeSessions.get(sessionId);
       if (!session) {
-        // Session not active yet — try to activate it so we can fetch skills.
+        // Session not active yet — try to activate it so we can fetch commands.
         // Use the directory passed from engine-manager (from conversationStore),
         // falling back to the in-memory sessionDirectories map.
         const dir = directory || this.sessionDirectories.get(sessionId);
         if (dir) {
           try {
-            copilotLog.info(`[Copilot] listCommands: activating session ${sessionId} to fetch skills`);
+            copilotLog.info(`[Copilot] listCommands: activating session ${sessionId} to fetch commands`);
             session = await this.ensureActiveSession(sessionId, dir);
           } catch (err) {
             copilotLog.warn(`[Copilot] listCommands: failed to activate session:`, err);
@@ -952,9 +999,9 @@ export class CopilotSdkAdapter extends EngineAdapter {
       }
       if (session) {
         try {
-          await this.fetchSkills(session);
+          await this.fetchCommands(session);
         } catch (err) {
-          copilotLog.warn(`[Copilot] Failed to fetch skills on listCommands:`, err);
+          copilotLog.warn(`[Copilot] Failed to fetch commands on listCommands:`, err);
         }
       }
     } else {
@@ -962,9 +1009,9 @@ export class CopilotSdkAdapter extends EngineAdapter {
       const firstSession = this.activeSessions.values().next().value;
       if (firstSession) {
         try {
-          await this.fetchSkills(firstSession);
+          await this.fetchCommands(firstSession);
         } catch (err) {
-          copilotLog.warn(`[Copilot] Failed to fetch skills on listCommands (fallback):`, err);
+          copilotLog.warn(`[Copilot] Failed to fetch commands on listCommands (fallback):`, err);
         }
       }
     }
@@ -978,16 +1025,109 @@ export class CopilotSdkAdapter extends EngineAdapter {
     args: string,
     options?: { mode?: string; modelId?: string; directory?: string },
   ): Promise<CommandInvokeResult> {
-    // Send the command as text — Copilot CLI intercepts /command prefix.
-    // The CLI emits a command.execute event which we acknowledge via
-    // handlePendingCommand() in handleCommandExecute().
-    const commandText = `/${commandName}${args ? ` ${args}` : ""}`;
-    const message = await this.sendMessage(
+    const session = await this.ensureActiveSession(sessionId, options?.directory);
+
+    const tryInvoke = async () =>
+      session.rpc.commands.invoke({
+        name: commandName,
+        input: args ? args : undefined,
+      });
+
+    let result;
+    try {
+      result = await tryInvoke();
+    } catch (err) {
+      copilotLog.warn(
+        `[Copilot][${sessionId}] commands.invoke failed for /${commandName}:`,
+        err,
+      );
+      // If the skill exists but is disabled, SDK 1.0 rejects invoke().
+      // The user explicitly typed /command-name, so treat it as an implicit
+      // session-scoped enable and retry once.
+      let enabledForRetry = false;
+      try {
+        await session.rpc.skills.enable({ name: commandName });
+        enabledForRetry = true;
+      } catch (enableErr) {
+        copilotLog.debug(
+          `[Copilot][${sessionId}] auto-enable of ${commandName} failed:`,
+          enableErr,
+        );
+      }
+      if (enabledForRetry) {
+        try {
+          result = await tryInvoke();
+        } catch (retryErr) {
+          copilotLog.warn(
+            `[Copilot][${sessionId}] commands.invoke retry failed for /${commandName}:`,
+            retryErr,
+          );
+          return { handledAsCommand: false };
+        }
+      } else {
+        return { handledAsCommand: false };
+      }
+    }
+
+    copilotLog.debug(`[Copilot][${sessionId}] commands.invoke /${commandName} → ${result.kind}`);
+
+    switch (result.kind) {
+      case "text":
+      case "completed": {
+        // SDK fully handled the command — emit an assistant message displaying
+        // the textual output without going through the agent loop.
+        const text = result.kind === "text" ? result.text : (result.message ?? "");
+        const message = this.emitLocalAssistantMessage(sessionId, text);
+        return { handledAsCommand: true, message };
+      }
+      case "agent-prompt": {
+        // Skill expanded into a prompt for the agent. Send the expanded prompt
+        // through the normal turn flow but suppress the duplicated user
+        // message — engine-manager already persisted the original "/cmd args".
+        const message = await this.sendMessage(
+          sessionId,
+          [{ type: "text", text: result.prompt }],
+          { ...options, _internalSuppressUserEmit: true } as any,
+        );
+        return { handledAsCommand: true, message };
+      }
+      case "select-subcommand": {
+        // Multi-step selection — surface the options as a plain assistant
+        // message so the user can re-invoke with the chosen subcommand.
+        const lines = [result.title, "", ...result.options.map((o) => `- /${commandName} ${o.name}${o.description ? ` — ${o.description}` : ""}`)];
+        const message = this.emitLocalAssistantMessage(sessionId, lines.join("\n"));
+        return { handledAsCommand: true, message };
+      }
+      default:
+        return { handledAsCommand: false };
+    }
+  }
+
+  /**
+   * Emit a synthetic assistant message containing the given text. Used for
+   * slash commands whose output the SDK returns directly (no agent turn).
+   */
+  private emitLocalAssistantMessage(sessionId: string, text: string): UnifiedMessage {
+    const now = Date.now();
+    const messageId = timeId("msg");
+    const message: UnifiedMessage = {
+      id: messageId,
       sessionId,
-      [{ type: "text", text: commandText }],
-      options,
-    );
-    return { handledAsCommand: true, message };
+      role: "assistant",
+      time: { created: now, completed: now },
+      parts: [
+        {
+          id: timeId("part"),
+          messageId,
+          sessionId,
+          type: "text",
+          text,
+        },
+      ],
+    };
+    this.appendMessageToHistory(sessionId, message);
+    this.emit("message.updated", { sessionId, message });
+    return message;
   }
 
   /**
@@ -999,7 +1139,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
     sessionId: string,
     data: { requestId: string; command: string; commandName: string; args: string },
   ): Promise<void> {
-    copilotLog.info(
+    copilotLog.debug(
       `[Copilot][${sessionId}] command.execute: /${data.commandName} ${data.args} (requestId=${data.requestId})`,
     );
     try {
@@ -1015,53 +1155,56 @@ export class CopilotSdkAdapter extends EngineAdapter {
   }
 
   /**
-   * Handle commands.changed event — refresh the cached command list.
+   * Handle command.queued event — the SDK runtime emits this when a slash
+   * command is enqueued (e.g. when the user types "/cmd" directly into the
+   * message input rather than invoking via the SDK command API). We respond
+   * with `handled: false` so the runtime executes the command itself
+   * (running skills, builtins, etc.) rather than waiting indefinitely.
    */
-  private handleCommandsChanged(
+  private async handleCommandQueued(
     sessionId: string,
-    data: { commands: Array<{ name: string; description?: string }> },
-  ): void {
-    if (Array.isArray(data?.commands)) {
-      this.cachedCommands = data.commands.map(cmd => ({
-        name: cmd.name,
-        description: cmd.description ?? "",
-      }));
-      this.emit("commands.changed", {
-        engineType: this.engineType,
-        commands: this.cachedCommands,
-      });
-      copilotLog.info(
-        `[Copilot][${sessionId}] Commands updated: ${this.cachedCommands.length} commands`,
-      );
+    data: { requestId: string; command: string },
+  ): Promise<void> {
+    copilotLog.debug(
+      `[Copilot][${sessionId}] command.queued: ${data.command} (requestId=${data.requestId}) → responding handled=false`,
+    );
+    try {
+      const session = this.activeSessions.get(sessionId);
+      if (session) {
+        await session.rpc.commands.respondToQueuedCommand({
+          requestId: data.requestId,
+          result: { handled: false },
+        });
+      }
+    } catch (err) {
+      copilotLog.warn(`[Copilot][${sessionId}] Failed to respond to queued command:`, err);
     }
   }
 
   /**
-   * Handle session.skills_loaded event — the Copilot CLI emits this when
-   * skills are loaded or reloaded from disk. Update cached commands from
-   * the skills data.
+   * Handle commands.changed event — the SDK runtime emits this when the set
+   * of available commands changes (e.g. skills enabled/disabled, plugins
+   * loaded, client commands re-registered). The event payload only includes
+   * SDK-registered commands, so we re-query the full command list rather
+   * than blindly overwriting the cache.
    */
-  private handleSkillsLoaded(
-    sessionId: string,
-    data: { skills: Array<{ name: string; description?: string; userInvocable?: boolean; source?: string }> },
-  ): void {
-    if (Array.isArray(data?.skills)) {
-      this.cachedCommands = data.skills
-        .filter((s) => s.userInvocable !== false)
-        .map((s) => ({
-          name: s.name,
-          description: s.description ?? "",
-          source: s.source,
-          userInvocable: s.userInvocable,
-        }));
-      this.emit("commands.changed", {
-        engineType: this.engineType,
-        commands: this.cachedCommands,
-      });
-      copilotLog.info(
-        `[Copilot][${sessionId}] Skills loaded: ${this.cachedCommands.length} skills`,
-      );
-    }
+  private async handleCommandsChanged(sessionId: string): Promise<void> {
+    const session = this.activeSessions.get(sessionId);
+    if (!session) return;
+    copilotLog.debug(`[Copilot][${sessionId}] commands.changed → refreshing command list`);
+    await this.fetchCommands(session);
+  }
+
+  /**
+   * Handle session.skills_loaded event — the Copilot CLI emits this when
+   * skills are loaded or reloaded from disk. Refresh the cached command
+   * list so newly discovered skills become invocable.
+   */
+  private async handleSkillsLoaded(sessionId: string): Promise<void> {
+    const session = this.activeSessions.get(sessionId);
+    if (!session) return;
+    copilotLog.debug(`[Copilot][${sessionId}] session.skills_loaded → refreshing command list`);
+    await this.fetchCommands(session);
   }
 
   private setStatus(status: EngineStatus, error?: string): void {
@@ -1104,11 +1247,15 @@ export class CopilotSdkAdapter extends EngineAdapter {
   }
 
   private async ensureActiveSession(sessionId: string, directory?: string): Promise<CopilotSession> {
-    // If client reconnected (e.g. CLI restarted), cached sessions are stale
-    const clientState = this.client?.getState?.();
-    if (clientState && clientState !== "connected") {
-      copilotLog.warn(`Client state is "${clientState}", clearing all cached sessions`);
-      this.evictAllSessions();
+    // If client reconnected (e.g. CLI restarted), cached sessions are stale.
+    // Probe with ping; on failure clear cached sessions before continuing.
+    if (this.client) {
+      try {
+        await this.client.ping();
+      } catch (err) {
+        copilotLog.warn(`Client ping failed, clearing all cached sessions:`, err);
+        this.evictAllSessions();
+      }
     }
 
     const existing = this.activeSessions.get(sessionId);
@@ -1125,6 +1272,8 @@ export class CopilotSdkAdapter extends EngineAdapter {
       systemMessage: { mode: "append" as const, content: CODEMUX_IDENTITY_PROMPT },
       onPermissionRequest: (req, ctx) => this.handlePermissionRequest(req, ctx),
       onUserInputRequest: (req, ctx) => this.handleUserInputRequest(req as any, ctx),
+      enableSkills: true,
+      enableConfigDiscovery: true,
     };
 
     copilotLog.info(`Resuming session ${sessionId}...`);
@@ -1147,6 +1296,8 @@ export class CopilotSdkAdapter extends EngineAdapter {
           systemMessage: { mode: "append" as const, content: CODEMUX_IDENTITY_PROMPT },
           onPermissionRequest: (req, ctx) => this.handlePermissionRequest(req, ctx),
           onUserInputRequest: (req, ctx) => this.handleUserInputRequest(req as any, ctx),
+          enableSkills: true,
+          enableConfigDiscovery: true,
         };
         const newSession = await this.client!.createSession(newConfig);
         this.subscribeToSessionEvents(newSession);
@@ -1196,16 +1347,18 @@ export class CopilotSdkAdapter extends EngineAdapter {
         case "command.execute":
           this.handleCommandExecute(sessionId, event.data as any);
           break;
+        case "command.queued":
+          this.handleCommandQueued(sessionId, event.data as any);
+          break;
         case "command.completed":
-          // Command completed — no action needed on our side
-          copilotLog.info(`[Copilot][${sessionId}] Command completed: requestId=${(event.data as any)?.requestId}`);
+          copilotLog.debug(`[Copilot][${sessionId}] Command completed: requestId=${(event.data as any)?.requestId}`);
           break;
         case "commands.changed":
-          this.handleCommandsChanged(sessionId, event.data as any);
+          this.handleCommandsChanged(sessionId);
           break;
         case "session.skills_loaded":
-          // Skills loaded/reloaded — refresh command list from the event data
-          this.handleSkillsLoaded(sessionId, event.data as any);
+          // Skills loaded/reloaded — refresh command list from the SDK.
+          this.handleSkillsLoaded(sessionId);
           break;
       }
     } catch (err) {

--- a/electron/main/engines/copilot/index.ts
+++ b/electron/main/engines/copilot/index.ts
@@ -1087,7 +1087,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
         const message = await this.sendMessage(
           sessionId,
           [{ type: "text", text: result.prompt }],
-          { ...options, _internalSuppressUserEmit: true } as any,
+          { ...options, _internalSuppressUserEmit: true },
         );
         return { handledAsCommand: true, message };
       }
@@ -1247,8 +1247,14 @@ export class CopilotSdkAdapter extends EngineAdapter {
   }
 
   private async ensureActiveSession(sessionId: string, directory?: string): Promise<CopilotSession> {
-    // If client reconnected (e.g. CLI restarted), cached sessions are stale.
-    // Probe with ping; on failure clear cached sessions before continuing.
+    const existing = this.activeSessions.get(sessionId);
+    if (existing) return existing;
+    this.ensureClient();
+
+    // Cache miss — probe client health before resume/create. If the client
+    // reconnected (e.g. CLI restarted) the cached session map is stale and
+    // any stragglers must be evicted before we resume/create. Probing only
+    // on miss keeps hot paths like sendMessage at zero ping overhead.
     if (this.client) {
       try {
         await this.client.ping();
@@ -1257,10 +1263,6 @@ export class CopilotSdkAdapter extends EngineAdapter {
         this.evictAllSessions();
       }
     }
-
-    const existing = this.activeSessions.get(sessionId);
-    if (existing) return existing;
-    this.ensureClient();
 
     const workingDirectory = directory || this.sessionDirectories.get(sessionId);
     const sdkReasoningEffort = this.getSdkReasoningEffort(sessionId);
@@ -1300,7 +1302,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
           enableConfigDiscovery: true,
         };
         const newSession = await this.client!.createSession(newConfig);
-        this.subscribeToSessionEvents(newSession);
+        this.subscribeToSessionEvents(newSession, sessionId);
         this.activeSessions.set(sessionId, newSession);
         if (workingDirectory) this.sessionDirectories.set(sessionId, workingDirectory);
         return newSession;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.137",
-    "@github/copilot-sdk": "^1.0.0-beta.3",
+    "@github/copilot-sdk": "1.0.0",
     "@larksuiteoapi/node-sdk": "^1.42.0",
     "@opencode-ai/sdk": "^1.14.41",
     "@parcel/watcher": "^2.5.1",

--- a/tests/unit/electron/engines/copilot/converters.test.ts
+++ b/tests/unit/electron/engines/copilot/converters.test.ts
@@ -967,7 +967,7 @@ describe('copilot-converters', () => {
         modifiedTime: new Date('2025-01-01T01:00:00Z'),
         isRemote: false,
         context: {
-          cwd: 'C:\\Users\\test\\project',
+          workingDirectory: 'C:\\Users\\test\\project',
           repository: 'repo',
           branch: 'main',
           gitRoot: '/git',
@@ -994,10 +994,10 @@ describe('copilot-converters', () => {
 
     // --- Branch coverage additions ---
 
-    it('falls back to homedir when context has no cwd property', () => {
+    it('falls back to homedir when context has no workingDirectory property', () => {
       const meta = {
         sessionId: 's3',
-        summary: 'No cwd',
+        summary: 'No workingDirectory',
         startTime: new Date('2025-03-01'),
         modifiedTime: new Date('2025-03-02'),
         isRemote: true,
@@ -1026,14 +1026,14 @@ describe('copilot-converters', () => {
       expect(session.engineMeta?.gitRoot).toBeUndefined();
     });
 
-    it('normalizes Windows backslash paths in cwd to forward slashes', () => {
+    it('normalizes Windows backslash paths in workingDirectory to forward slashes', () => {
       const meta = {
         sessionId: 's5',
         summary: 'Windows path',
         startTime: new Date('2025-05-01'),
         modifiedTime: new Date('2025-05-02'),
         isRemote: false,
-        context: { cwd: 'D:\\Projects\\my-app\\src' },
+        context: { workingDirectory: 'D:\\Projects\\my-app\\src' },
       } as any;
       const session = metadataToSession('copilot', meta);
       expect(session.directory).toBe('D:/Projects/my-app/src');

--- a/tests/unit/electron/engines/copilot/index.test.ts
+++ b/tests/unit/electron/engines/copilot/index.test.ts
@@ -15,6 +15,7 @@ const {
   mockClientInstance,
   mockSessionBase,
   CopilotClientConstructor,
+  RuntimeConnectionMock,
 } = vi.hoisted(() => {
   let _idCounter = 0;
 
@@ -28,13 +29,23 @@ const {
     send: vi.fn(async function() {}),
     abort: vi.fn(async function() {}),
     disconnect: vi.fn(async function() {}),
-    getMessages: vi.fn(async function() { return []; }),
+    getEvents: vi.fn(async function() { return []; }),
     rpc: {
       model: { switchTo: vi.fn(async function() {}) },
       mode: { set: vi.fn(async function() {}) },
       name: { set: vi.fn(async function() {}) },
-      skills: { list: vi.fn(async function() { return { skills: [] }; }) },
-      commands: { handlePendingCommand: vi.fn(async function() {}) },
+      commands: {
+        list: vi.fn(async function() { return { commands: [] }; }),
+        invoke: vi.fn(async function() { return { kind: "completed" }; }),
+        handlePendingCommand: vi.fn(async function() {}),
+        respondToQueuedCommand: vi.fn(async function() {}),
+      },
+      skills: {
+        ensureLoaded: vi.fn(async function() {}),
+        list: vi.fn(async function() { return { skills: [] }; }),
+        enable: vi.fn(async function() {}),
+        disable: vi.fn(async function() {}),
+      },
     },
   };
 
@@ -56,11 +67,16 @@ const {
     deleteSession: vi.fn(async function() {}),
     listModels: vi.fn(async function() { return []; }),
     getSessionMetadata: vi.fn(async function() { return undefined; }),
-    getState: vi.fn(function() { return "connected"; }),
   };
 
   // Must use function() (not arrow) so it can be called with `new`.
   const CopilotClientConstructor = vi.fn(function() { return mockClientInstance; });
+
+  const RuntimeConnectionMock = {
+    forStdio: vi.fn((opts?: { path?: string }) => ({ kind: "stdio" as const, path: opts?.path })),
+    forTcp: vi.fn((opts?: { port?: number }) => ({ kind: "tcp" as const, port: opts?.port })),
+    forUri: vi.fn((url: string) => ({ kind: "uri" as const, url })),
+  };
 
   return {
     writeFileSyncMock: vi.fn(),
@@ -73,6 +89,7 @@ const {
     mockClientInstance,
     mockSessionBase,
     CopilotClientConstructor,
+    RuntimeConnectionMock,
   };
 });
 
@@ -117,6 +134,7 @@ vi.mock("../../../../../electron/main/utils/id-gen", () => ({
 vi.mock("@github/copilot-sdk", () => ({
   CopilotClient: CopilotClientConstructor,
   CopilotSession: vi.fn(),
+  RuntimeConnection: RuntimeConnectionMock,
 }));
 
 // ============================================================================
@@ -158,13 +176,23 @@ function makeMockSession(sessionId = "s1") {
     send: vi.fn(async () => {}),
     abort: vi.fn(async () => {}),
     disconnect: vi.fn(async () => {}),
-    getMessages: vi.fn(async () => []),
+    getEvents: vi.fn(async () => []),
     rpc: {
       model: { switchTo: vi.fn(async () => {}) },
       mode: { set: vi.fn(async () => {}) },
       name: { set: vi.fn(async () => {}) },
-      skills: { list: vi.fn(async () => ({ skills: [] })) },
-      commands: { handlePendingCommand: vi.fn(async () => {}) },
+      commands: {
+        list: vi.fn(async () => ({ commands: [] })),
+        invoke: vi.fn(async () => ({ kind: "completed" })),
+        handlePendingCommand: vi.fn(async () => {}),
+        respondToQueuedCommand: vi.fn(async () => {}),
+      },
+      skills: {
+        ensureLoaded: vi.fn(async () => {}),
+        list: vi.fn(async () => ({ skills: [] })),
+        enable: vi.fn(async () => {}),
+        disable: vi.fn(async () => {}),
+      },
     },
   };
 }
@@ -394,6 +422,16 @@ describe("CopilotSdkAdapter", () => {
       );
     });
 
+    it("enables skill loading and config discovery so user-installed skills are discovered", async () => {
+      await adapter.createSession("/repo");
+      expect(mockClientInstance.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enableSkills: true,
+          enableConfigDiscovery: true,
+        }),
+      );
+    });
+
     it("subscribes to session events after creation", async () => {
       const newSess = { ...mockSessionBase, sessionId: "s-new", on: vi.fn(() => vi.fn()) };
       mockClientInstance.createSession.mockResolvedValueOnce(newSess);
@@ -403,8 +441,8 @@ describe("CopilotSdkAdapter", () => {
       expect(newSess.on).toHaveBeenCalledTimes(1);
     });
 
-    it("fetches initial skills to populate cachedCommands before returning", async () => {
-      const fetchSpy = vi.spyOn(adapter as any, "fetchSkills").mockResolvedValue(undefined);
+    it("fetches initial commands to populate cachedCommands before returning", async () => {
+      const fetchSpy = vi.spyOn(adapter as any, "fetchCommands").mockResolvedValue(undefined);
       await adapter.createSession("/repo");
       expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
@@ -524,8 +562,8 @@ describe("CopilotSdkAdapter", () => {
       await expect((adapter as any).ensureActiveSession("s1", "/repo")).rejects.toThrow("network error");
     });
 
-    it("evicts all cached sessions when client state is not 'connected'", async () => {
-      mockClientInstance.getState.mockReturnValueOnce("disconnected");
+    it("evicts all cached sessions when client.ping fails (CLI disconnected)", async () => {
+      mockClientInstance.ping.mockRejectedValueOnce(new Error("not connected"));
       const evictSpy = vi.spyOn(adapter as any, "evictAllSessions");
       (adapter as any).activeSessions.set("s1", makeMockSession("s1"));
 
@@ -1983,58 +2021,128 @@ describe("CopilotSdkAdapter", () => {
   // I. Commands & Skills
   // ============================================================================
 
-  describe("fetchSkills()", () => {
-    it("caches user-invocable commands and emits commands.changed", async () => {
+  describe("fetchCommands()", () => {
+    it("caches commands from commands.list and emits commands.changed", async () => {
       const commandEvents: any[] = [];
       adapter.on("commands.changed", (e) => commandEvents.push(e));
-      const sess = {
-        rpc: {
-          skills: {
-            list: vi.fn(async () => ({
-              skills: [
-                { name: "fix", description: "Fix issues", userInvocable: true, source: "project" },
-                { name: "internal", description: "Internal", userInvocable: false },
-              ],
-            })),
-          },
-        },
-      };
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [
+          { name: "fix", description: "Fix issues", input: { hint: "<file>" } },
+          { name: "test", description: "Run tests" },
+        ],
+      });
 
-      await (adapter as any).fetchSkills(sess);
+      await (adapter as any).fetchCommands(sess);
 
-      // userInvocable: false filtered out (source code: filter s.userInvocable !== false)
-      // Actually re-reading: .filter((s: any) => s.userInvocable !== false) keeps userInvocable:true and undefined
-      // "internal" has userInvocable:false so it is filtered OUT
+      expect(sess.rpc.commands.list).toHaveBeenCalledWith({
+        includeBuiltins: true,
+        includeSkills: true,
+        includeClientCommands: true,
+      });
       const cached = (adapter as any).cachedCommands;
-      expect(cached.find((c: any) => c.name === "fix")).toBeDefined();
-      expect(cached.find((c: any) => c.name === "internal")).toBeUndefined();
+      expect(cached).toHaveLength(2);
+      expect(cached.find((c: any) => c.name === "fix")).toMatchObject({
+        name: "fix",
+        description: "Fix issues",
+        argumentHint: "<file>",
+      });
       expect(commandEvents).toHaveLength(1);
       expect(commandEvents[0].engineType).toBe("copilot");
     });
 
-    it("handles skills returned as a flat array (not wrapped in {skills})", async () => {
-      const sess = {
-        rpc: {
-          skills: {
-            list: vi.fn(async () => [{ name: "cmd1", description: "Cmd 1" }]),
-          },
-        },
-      };
+    it("calls skills.ensureLoaded so disk-installed skills are registered before listing", async () => {
+      const sess = makeMockSession("s1");
 
-      await (adapter as any).fetchSkills(sess);
+      await (adapter as any).fetchCommands(sess);
 
-      expect((adapter as any).cachedCommands).toHaveLength(1);
-      expect((adapter as any).cachedCommands[0].name).toBe("cmd1");
+      expect(sess.rpc.skills.ensureLoaded).toHaveBeenCalledTimes(1);
+    });
+
+    it("merges non-builtin skills from skills.list that commands.list omits, regardless of userInvocable flag", async () => {
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "fix", description: "Builtin fix" }],
+      });
+      sess.rpc.skills.list.mockResolvedValueOnce({
+        skills: [
+          { name: "deploy", description: "Custom deploy skill", userInvocable: true, enabled: true, source: "personal-copilot" },
+          { name: "fix", description: "Skill fix variant", userInvocable: true, enabled: true, source: "project" },
+          // userInvocable=false should STILL appear so user-installed
+          // agent-targeted skills remain accessible via slash commands.
+          { name: "agent-helper", description: "Agent-only helper", userInvocable: false, enabled: true, source: "project" },
+          // builtin skills are skipped (already covered by commands.list).
+          { name: "builtin-skill", description: "Internal builtin", userInvocable: false, enabled: true, source: "builtin" },
+        ],
+      });
+
+      await (adapter as any).fetchCommands(sess);
+
+      const cached = (adapter as any).cachedCommands;
+      const names = cached.map((c: any) => c.name);
+      expect(names).toContain("fix");
+      expect(names).toContain("deploy");
+      expect(names).toContain("agent-helper");
+      expect(names).not.toContain("builtin-skill");
+      // skills.list entry duplicates of an existing command name must not overwrite
+      expect(cached.find((c: any) => c.name === "fix").description).toBe("Builtin fix");
+    });
+
+    it("includes skills even when commands.list returns only builtins", async () => {
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "help", description: "Built-in help" }],
+      });
+      sess.rpc.skills.list.mockResolvedValueOnce({
+        skills: [
+          { name: "my-skill", description: "User skill", userInvocable: true, enabled: true, source: "personal-copilot" },
+        ],
+      });
+
+      await (adapter as any).fetchCommands(sess);
+
+      const names = (adapter as any).cachedCommands.map((c: any) => c.name);
+      expect(names).toEqual(expect.arrayContaining(["help", "my-skill"]));
+    });
+
+    it("continues when skills.ensureLoaded fails", async () => {
+      const sess = makeMockSession("s1");
+      sess.rpc.skills.ensureLoaded.mockRejectedValueOnce(new Error("ensureLoaded failed"));
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "ok", description: "" }],
+      });
+
+      await (adapter as any).fetchCommands(sess);
+
+      expect((adapter as any).cachedCommands.map((c: any) => c.name)).toEqual(["ok"]);
+    });
+
+    it("continues when skills.list fallback fails", async () => {
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "ok", description: "" }],
+      });
+      sess.rpc.skills.list.mockRejectedValueOnce(new Error("skills.list failed"));
+
+      await (adapter as any).fetchCommands(sess);
+
+      expect((adapter as any).cachedCommands.map((c: any) => c.name)).toEqual(["ok"]);
+    });
+
+    it("treats missing commands array as empty list", async () => {
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({} as any);
+
+      await (adapter as any).fetchCommands(sess);
+
+      expect((adapter as any).cachedCommands).toEqual([]);
     });
 
     it("swallows errors and logs a warning", async () => {
-      const sess = {
-        rpc: {
-          skills: { list: vi.fn(async () => { throw new Error("RPC failed"); }) },
-        },
-      };
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockRejectedValueOnce(new Error("RPC failed"));
 
-      await expect((adapter as any).fetchSkills(sess)).resolves.toBeUndefined();
+      await expect((adapter as any).fetchCommands(sess)).resolves.toBeUndefined();
     });
   });
 
@@ -2048,17 +2156,12 @@ describe("CopilotSdkAdapter", () => {
       expect(result[0].name).toBe("fix");
     });
 
-    it("fetches skills from active session when cache is empty", async () => {
+    it("fetches commands from active session when cache is empty", async () => {
       await adapter.start();
-      const sess = {
-        rpc: {
-          skills: {
-            list: vi.fn(async () => ({
-              skills: [{ name: "cmd", description: "Cmd", userInvocable: true }],
-            })),
-          },
-        },
-      };
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "cmd", description: "Cmd" }],
+      });
       (adapter as any).activeSessions.set("s1", sess);
 
       const result = await adapter.listCommands("s1");
@@ -2069,18 +2172,13 @@ describe("CopilotSdkAdapter", () => {
 
     it("uses the first active session when no sessionId is provided", async () => {
       await adapter.start();
-      const sess = {
-        rpc: {
-          skills: {
-            list: vi.fn(async () => ({
-              skills: [{ name: "fallback-cmd", description: "" }],
-            })),
-          },
-        },
-      };
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "fallback-cmd", description: "" }],
+      });
       (adapter as any).activeSessions.set("s1", sess);
 
-      await adapter.listCommands(); // no sessionId
+      await adapter.listCommands();
 
       expect((adapter as any).cachedCommands[0].name).toBe("fallback-cmd");
     });
@@ -2119,55 +2217,236 @@ describe("CopilotSdkAdapter", () => {
     });
   });
 
-  describe("handleCommandsChanged()", () => {
-    it("updates cachedCommands and emits commands.changed", () => {
-      const events: any[] = [];
-      adapter.on("commands.changed", (e) => events.push(e));
+  describe("handleCommandQueued()", () => {
+    it("responds to the queued command with handled=false so runtime executes it", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      (adapter as any).activeSessions.set("s1", sess);
 
-      (adapter as any).handleCommandsChanged("s1", {
-        commands: [
-          { name: "fix", description: "Fix" },
-          { name: "test", description: "Test" },
-        ],
+      await (adapter as any).handleCommandQueued("s1", {
+        requestId: "req-q1",
+        command: "/fix",
       });
 
-      expect((adapter as any).cachedCommands).toHaveLength(2);
-      expect(events).toHaveLength(1);
-      expect(events[0].commands.map((c: any) => c.name)).toEqual(["fix", "test"]);
+      expect(sess.rpc.commands.respondToQueuedCommand).toHaveBeenCalledWith({
+        requestId: "req-q1",
+        result: { handled: false },
+      });
     });
 
-    it("is a no-op when commands data is not an array", () => {
+    it("is a no-op when the session is not active", async () => {
+      await adapter.start();
+      const sess = makeMockSession("missing");
+
+      await (adapter as any).handleCommandQueued("missing", {
+        requestId: "req-q2",
+        command: "/x",
+      });
+
+      expect(sess.rpc.commands.respondToQueuedCommand).not.toHaveBeenCalled();
+    });
+
+    it("swallows errors when respondToQueuedCommand fails", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.respondToQueuedCommand.mockRejectedValue(new Error("rpc error"));
+      (adapter as any).activeSessions.set("s1", sess);
+
+      await expect(
+        (adapter as any).handleCommandQueued("s1", { requestId: "req-q3", command: "/fix" }),
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe("invokeCommand()", () => {
+    it("returns handledAsCommand=true with assistant message for kind=text", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke.mockResolvedValueOnce({ kind: "text", text: "hello" });
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const result = await adapter.invokeCommand("s1", "fix", "");
+
+      expect(sess.rpc.commands.invoke).toHaveBeenCalledWith({ name: "fix", input: undefined });
+      expect(result.handledAsCommand).toBe(true);
+      expect(result.message?.parts?.[0]).toMatchObject({ type: "text", text: "hello" });
+    });
+
+    it("returns handledAsCommand=true with completed.message for kind=completed", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke.mockResolvedValueOnce({ kind: "completed", message: "done" });
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const result = await adapter.invokeCommand("s1", "fix", "arg1");
+
+      expect(sess.rpc.commands.invoke).toHaveBeenCalledWith({ name: "fix", input: "arg1" });
+      expect(result.handledAsCommand).toBe(true);
+      expect(result.message?.parts?.[0]).toMatchObject({ type: "text", text: "done" });
+    });
+
+    it("forwards agent-prompt result through sendMessage and suppresses duplicate user emit", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke.mockResolvedValueOnce({
+        kind: "agent-prompt",
+        prompt: "Please refactor the auth module",
+      });
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const sendSpy = vi
+        .spyOn(adapter as any, "sendMessage")
+        .mockResolvedValue({ id: "msg-1", role: "assistant", parts: [], time: { created: 0 } });
+
+      const result = await adapter.invokeCommand("s1", "refactor", "");
+
+      expect(sendSpy).toHaveBeenCalledTimes(1);
+      const [, parts, opts] = sendSpy.mock.calls[0];
+      expect(parts).toEqual([{ type: "text", text: "Please refactor the auth module" }]);
+      expect(opts).toMatchObject({ _internalSuppressUserEmit: true });
+      expect(result.handledAsCommand).toBe(true);
+    });
+
+    it("returns kind=select-subcommand options as an assistant message listing choices", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke.mockResolvedValueOnce({
+        kind: "select-subcommand",
+        title: "Pick a subcommand",
+        options: [
+          { name: "fast", description: "Quick run" },
+          { name: "thorough", description: "Slow but careful" },
+        ],
+      });
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const result = await adapter.invokeCommand("s1", "run", "");
+
+      expect(result.handledAsCommand).toBe(true);
+      const text = (result.message?.parts?.[0] as any).text as string;
+      expect(text).toContain("Pick a subcommand");
+      expect(text).toContain("/run fast");
+      expect(text).toContain("/run thorough");
+    });
+
+    it("auto-enables a disabled skill and retries when the first invoke fails", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke
+        .mockRejectedValueOnce(new Error("skill is disabled"))
+        .mockResolvedValueOnce({ kind: "text", text: "now works" });
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const result = await adapter.invokeCommand("s1", "my-skill", "");
+
+      expect(sess.rpc.skills.enable).toHaveBeenCalledWith({ name: "my-skill" });
+      expect(sess.rpc.commands.invoke).toHaveBeenCalledTimes(2);
+      expect(result.handledAsCommand).toBe(true);
+      expect(result.message?.parts?.[0]).toMatchObject({ type: "text", text: "now works" });
+    });
+
+    it("returns handledAsCommand=false when both initial invoke and auto-enable retry fail", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke.mockRejectedValue(new Error("nope"));
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const result = await adapter.invokeCommand("s1", "broken", "");
+
+      expect(result.handledAsCommand).toBe(false);
+    });
+
+    it("returns handledAsCommand=false when invoke fails and skill cannot be enabled", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.invoke.mockRejectedValueOnce(new Error("not a skill"));
+      sess.rpc.skills.enable.mockRejectedValueOnce(new Error("unknown skill"));
+      (adapter as any).activeSessions.set("s1", sess);
+      (adapter as any).sessionDirectories.set("s1", "/repo");
+
+      const result = await adapter.invokeCommand("s1", "noexist", "");
+
+      expect(result.handledAsCommand).toBe(false);
+      // invoke should not be retried when enable fails
+      expect(sess.rpc.commands.invoke).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("handleCommandsChanged()", () => {
+    it("refreshes the cached command list via fetchCommands", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "deploy", description: "Deploy" }],
+      });
+      (adapter as any).activeSessions.set("s1", sess);
+
+      await (adapter as any).handleCommandsChanged("s1");
+
+      expect(sess.rpc.commands.list).toHaveBeenCalledWith({
+        includeBuiltins: true,
+        includeSkills: true,
+        includeClientCommands: true,
+      });
+      expect((adapter as any).cachedCommands.map((c: any) => c.name)).toEqual(["deploy"]);
+    });
+
+    it("is a no-op when the session is not active", async () => {
       const events: any[] = [];
       adapter.on("commands.changed", (e) => events.push(e));
 
-      (adapter as any).handleCommandsChanged("s1", { commands: null });
+      await (adapter as any).handleCommandsChanged("missing");
 
       expect(events).toHaveLength(0);
     });
   });
 
   describe("handleSkillsLoaded()", () => {
-    it("updates cachedCommands filtering out non-user-invocable skills", () => {
-      (adapter as any).handleSkillsLoaded("s1", {
-        skills: [
-          { name: "fix", description: "Fix", userInvocable: true, source: "project" },
-          { name: "internal", description: "Internal", userInvocable: false },
+    it("refreshes the cached command list via fetchCommands", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [
+          { name: "fix", description: "Fix" },
+          { name: "lint", description: "Lint" },
         ],
       });
+      (adapter as any).activeSessions.set("s1", sess);
 
-      const commands = (adapter as any).cachedCommands;
-      expect(commands.map((c: any) => c.name)).toEqual(["fix"]);
+      await (adapter as any).handleSkillsLoaded("s1");
+
+      expect((adapter as any).cachedCommands.map((c: any) => c.name)).toEqual(["fix", "lint"]);
     });
 
-    it("emits commands.changed after updating", () => {
+    it("emits commands.changed after refreshing", async () => {
+      await adapter.start();
+      const sess = makeMockSession("s1");
+      sess.rpc.commands.list.mockResolvedValueOnce({
+        commands: [{ name: "deploy", description: "Deploy" }],
+      });
+      (adapter as any).activeSessions.set("s1", sess);
+
       const events: any[] = [];
       adapter.on("commands.changed", (e) => events.push(e));
 
-      (adapter as any).handleSkillsLoaded("s1", {
-        skills: [{ name: "deploy", description: "Deploy", userInvocable: true }],
-      });
+      await (adapter as any).handleSkillsLoaded("s1");
 
       expect(events).toHaveLength(1);
+    });
+
+    it("is a no-op when the session is not active", async () => {
+      const events: any[] = [];
+      adapter.on("commands.changed", (e) => events.push(e));
+
+      await (adapter as any).handleSkillsLoaded("missing");
+
+      expect(events).toHaveLength(0);
     });
   });
 

--- a/tests/unit/electron/engines/copilot/index.test.ts
+++ b/tests/unit/electron/engines/copilot/index.test.ts
@@ -531,6 +531,32 @@ describe("CopilotSdkAdapter", () => {
       expect(mockClientInstance.resumeSession).not.toHaveBeenCalled();
     });
 
+    it("does not call client.ping on cache hit (zero latency overhead on hot paths)", async () => {
+      const existing = makeMockSession("s1");
+      (adapter as any).activeSessions.set("s1", existing);
+      mockClientInstance.ping.mockClear();
+
+      await (adapter as any).ensureActiveSession("s1");
+
+      expect(mockClientInstance.ping).not.toHaveBeenCalled();
+    });
+
+    it("falls back to createSession with the original sessionId for event routing", async () => {
+      mockClientInstance.resumeSession.mockRejectedValueOnce(new Error("Session not found"));
+      const onSpy = vi.fn(() => vi.fn());
+      const created = { ...mockSessionBase, sessionId: "s-different-id", on: onSpy };
+      mockClientInstance.createSession.mockResolvedValueOnce(created);
+
+      const result = await (adapter as any).ensureActiveSession("s1", "/repo");
+
+      expect(result).toBe(created);
+      // activeSessions and sessionUnsubscribers must be keyed under the
+      // *original* sessionId so event routing keeps working after fallback.
+      expect((adapter as any).activeSessions.get("s1")).toBe(created);
+      expect((adapter as any).sessionUnsubscribers.has("s1")).toBe(true);
+      expect((adapter as any).activeSessions.has("s-different-id")).toBe(false);
+    });
+
     it("resumes session from SDK when not in activeSessions", async () => {
       const resumed = { ...mockSessionBase, sessionId: "s1" };
       mockClientInstance.resumeSession.mockResolvedValueOnce(resumed);
@@ -563,13 +589,17 @@ describe("CopilotSdkAdapter", () => {
     });
 
     it("evicts all cached sessions when client.ping fails (CLI disconnected)", async () => {
+      // Pre-populate cache with a stale unrelated session so the request for
+      // "s1" hits the cache-miss path and triggers the ping probe.
+      (adapter as any).activeSessions.set("stale-id", makeMockSession("stale-id"));
+      (adapter as any).sessionUnsubscribers.set("stale-id", vi.fn());
       mockClientInstance.ping.mockRejectedValueOnce(new Error("not connected"));
       const evictSpy = vi.spyOn(adapter as any, "evictAllSessions");
-      (adapter as any).activeSessions.set("s1", makeMockSession("s1"));
 
       await (adapter as any).ensureActiveSession("s1", "/repo");
 
       expect(evictSpy).toHaveBeenCalledTimes(1);
+      expect((adapter as any).activeSessions.has("stale-id")).toBe(false);
     });
 
     it("includes reasoning effort in the resume config when set", async () => {


### PR DESCRIPTION
## Summary

Upgrades \`@github/copilot-sdk\` from \`^1.0.0-beta.3\` to \`1.0.0\` and fixes the breaking changes from the bump, including a regression where user-installed skills under \`~/.copilot/skills/\` stopped appearing in the slash-command list.

## SDK 1.0 breaking changes adapted

- \`CopilotClient\` now requires an explicit \`RuntimeConnection\` → switched to \`RuntimeConnection.forStdio({ path: cliPath })\`.
- \`session.getMessages()\` → \`session.getEvents()\`.
- \`session.getState()\` removed → health check now uses \`client.ping()\`.
- \`SessionContext.cwd\` → \`SessionContext.workingDirectory\`.

## Skill discovery regression — root cause

SDK 1.0 introduced two new \`SessionConfig\` flags that default to \`false\`:

| Flag | Default | Effect |
|------|---------|--------|
| \`enableSkills\` | \`false\` | When \`false\`, **no skills are loaded** regardless of \`skillDirectories\` or \`enableConfigDiscovery\`. |
| \`enableConfigDiscovery\` | \`false\` | When \`false\`, the SDK does not scan standard config folders (\`~/.copilot/skills\`, \`~/.agents/skills\`, \`~/.claude/skills\`). |

Because we didn't opt in to either, \`commands.list({ includeSkills: true })\` and \`skills.list()\` only returned the SDK's internal builtins (e.g. \`customize-cloud-agent\`). All user-installed skills were invisible.

All three \`createSession\` / \`resumeSession\` configs now pass \`enableSkills: true\` and \`enableConfigDiscovery: true\`.

## Slash-command flow rewrite

The old \`fetchSkills\` path was replaced with \`fetchCommands\` to align with the SDK 1.0 command API:

- **\`fetchCommands\`** — calls \`skills.ensureLoaded()\` first, then \`commands.list({ includeBuiltins, includeSkills, includeClientCommands })\`, and merges in any user skill that \`skills.list()\` surfaces but \`commands.list\` filters out (e.g. disabled / non-user-invocable).
- **\`invokeCommand\`** — now uses \`commands.invoke()\` and handles all four result kinds (\`text\`, \`completed\`, \`agent-prompt\`, \`select-subcommand\`). If invoke fails because the skill is disabled, it auto-enables session-scoped and retries once.
- **\`handleCommandQueued\`** (new) — responds to the \`command.queued\` event with \`{ handled: false }\` so the runtime executes builtins/skills directly instead of waiting on the client.
- **\`handleCommandsChanged\` / \`handleSkillsLoaded\`** — re-query the full command list instead of blindly overwriting the cache (the event payloads only include SDK-registered commands).

## Tests

258 copilot adapter tests pass, including new coverage for:

- \`enableSkills\` / \`enableConfigDiscovery\` flag injection
- \`fetchCommands\` happy-path and \`skills.list\` fallback merge
- \`invokeCommand\` all four result kinds + auto-enable retry + failure fallback
- \`handleCommandQueued\` responding with \`handled: false\`

Full unit suite: **3449 tests pass**, typecheck clean, build OK.

## Verification

Verified manually under \`npm run dev:isolated\` with 17 user skills under \`~/.copilot/skills/\`:

- Before fix: only built-in \`customize-cloud-agent\` shown in slash menu.
- After fix: all 17 user skills (architecture-patterns, cartography, code-simplifier, pr-resolve, …) appear and invoke correctly.