### PR TITLE
fix(settings): interpolate version in 'new version available' label

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import ImportHistoryModal from "../components/ImportHistoryModal";
 import { ensureGatewayInitialized, refreshEngineConfigState } from "../lib/engine-bootstrap";
 import { ChannelManagementSettings } from "../components/ChannelManagementSettings";
 import { TerminalSettingsSection } from "../components/TerminalSettingsSection";
-import { useI18n } from "../lib/i18n";
+import { useI18n, formatMessage } from "../lib/i18n";
 import { logger } from "../lib/logger";
 import { useAuthGuard } from "../lib/useAuthGuard";
 import { isElectron } from "../lib/platform";
@@ -38,6 +38,7 @@ export default function Settings() {
   // Update section state
   const [appVersion, setAppVersion] = createSignal("");
   const [updateCheckStatus, setUpdateCheckStatus] = createSignal<"idle" | "checking" | "up-to-date" | "available" | "error">("idle");
+  const [latestVersion, setLatestVersion] = createSignal("");
   const [autoCheckEnabled, setAutoCheckEnabled] = createSignal(true);
   const [launchAtLoginEnabled, setLaunchAtLoginEnabled] = createSignal(false);
 
@@ -226,6 +227,7 @@ export default function Settings() {
       return;
     }
     if (result.status === "available" || result.status === "downloading" || result.status === "downloaded") {
+      setLatestVersion(result.version ?? "");
       setUpdateCheckStatus("available");
     } else if (result.status === "error") {
       setUpdateCheckStatus("error");
@@ -986,7 +988,7 @@ export default function Settings() {
                       </Show>
                       <Show when={updateCheckStatus() === "available"}>
                         <p class="text-xs text-blue-600 dark:text-blue-400 mt-1">
-                          {t().update.available}
+                          {formatMessage(t().update.available, { version: latestVersion() })}
                         </p>
                       </Show>
                       <Show when={updateCheckStatus() === "error"}>


### PR DESCRIPTION
## Summary

When the settings page detected a new version, the blue notice rendered the raw translation string `New version v{version} available` (or its localized counterparts), leaving the `{version}` placeholder unreplaced.

## Root cause

`src/pages/Settings.tsx` rendered `t().update.available` directly without running it through `formatMessage`, and the new version number returned from `updateAPI.checkForUpdates()` was never stored.

## Fix

- Import `formatMessage` from `../lib/i18n`.
- Add a `latestVersion` signal to hold the version returned by the update check.
- In `handleCheckForUpdates`, store `result.version` when the status indicates an update is available (or already downloading/downloaded).
- Render the notice via `formatMessage(t().update.available, { version: latestVersion() })`.

## Verification

- `npm run typecheck` — passes.
- `bun run test:unit` — 3478 tests passing.