### PR TITLE
Fix Copilot initial model for lazy sessions

### DIFF
--- a/electron/main/engines/copilot/index.ts
+++ b/electron/main/engines/copilot/index.ts
@@ -44,6 +44,7 @@ import type {
   EngineCommand,
   CommandInvokeResult,
 } from "../../../../src/types/unified";
+import { isReasoningEffort } from "../../../../src/types/unified";
 
 import {
   convertEventsToMessages,
@@ -375,15 +376,25 @@ export class CopilotSdkAdapter extends EngineAdapter {
     }
   }
 
-  async createSession(directory: string): Promise<UnifiedSession> {
+  async createSession(directory: string, meta?: Record<string, unknown>): Promise<UnifiedSession> {
     this.ensureClient();
     const normalizedDir = directory.replaceAll("\\", "/");
     const mode = "autopilot";
+    const initialModelId = typeof meta?.codemuxInitialModelId === "string"
+      ? meta.codemuxInitialModelId
+      : this.currentModelId;
+    const initialReasoningEffort = isReasoningEffort(meta?.codemuxInitialReasoningEffort)
+      ? meta.codemuxInitialReasoningEffort
+      : undefined;
+    const sdkReasoningEffort = initialReasoningEffort
+      ? this.toSdkReasoningEffort(initialReasoningEffort)
+      : undefined;
 
     const config: SessionConfig = {
       workingDirectory: directory,
       streaming: true,
-      model: this.currentModelId ?? undefined,
+      model: initialModelId ?? undefined,
+      ...(sdkReasoningEffort ? { reasoningEffort: sdkReasoningEffort } : {}),
       onPermissionRequest: (req, ctx) => this.handlePermissionRequest(req, ctx),
       onUserInputRequest: (req, ctx) => this.handleUserInputRequest(req as any, ctx),
       systemMessage: { mode: "append" as const, content: CODEMUX_IDENTITY_PROMPT },
@@ -402,6 +413,8 @@ export class CopilotSdkAdapter extends EngineAdapter {
     this.activeSessions.set(sessionId, sdkSession);
     this.sessionModes.set(sessionId, mode);
     this.sessionDirectories.set(sessionId, directory);
+    if (initialModelId) this.currentModelId = initialModelId;
+    if (initialReasoningEffort) this.sessionReasoningEfforts.set(sessionId, initialReasoningEffort);
 
     const now = Date.now();
     const session: UnifiedSession = {

--- a/electron/main/engines/copilot/index.ts
+++ b/electron/main/engines/copilot/index.ts
@@ -403,7 +403,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
       // SDK 1.0 defaults both to false, which would hide all user-installed
       // skills from the slash command list.
       enableSkills: true,
-      enableConfigDiscovery: true,
+      enableConfigDiscovery: this.shouldEnableConfigDiscovery(initialModelId),
     };
 
     const sdkSession = await this.client!.createSession(config);
@@ -504,14 +504,26 @@ export class CopilotSdkAdapter extends EngineAdapter {
       _internalSuppressUserEmit?: boolean;
     },
   ): Promise<UnifiedMessage> {
-    const session = await this.ensureActiveSession(sessionId, options?.directory);
+    let session = await this.ensureActiveSession(sessionId, options?.directory);
     const now = Date.now();
 
     if (options?.modelId && options.modelId !== this.currentModelId) {
+      const previousModelId = this.currentModelId;
+      if (options.reasoningEffort !== undefined) {
+        if (options.reasoningEffort) {
+          this.sessionReasoningEfforts.set(sessionId, options.reasoningEffort);
+        } else {
+          this.sessionReasoningEfforts.delete(sessionId);
+        }
+      }
       this.currentModelId = options.modelId;
-      try {
-        await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, options.modelId));
-      } catch (err) {}
+      if (this.shouldReopenForConfigDiscovery(previousModelId, options.modelId)) {
+        session = await this.reopenActiveSession(sessionId, options.directory);
+      } else {
+        try {
+          await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, options.modelId));
+        } catch (err) {}
+      }
     }
 
     // Apply reasoning effort if it changed (same pattern as modelId)
@@ -524,9 +536,13 @@ export class CopilotSdkAdapter extends EngineAdapter {
           this.sessionReasoningEfforts.delete(sessionId);
         }
         if (this.currentModelId) {
-          try {
-            await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, this.currentModelId));
-          } catch (err) {}
+          if (this.isGeminiModel(this.currentModelId)) {
+            session = await this.reopenActiveSession(sessionId, options.directory);
+          } else {
+            try {
+              await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, this.currentModelId));
+            } catch (err) {}
+          }
         }
       }
     }
@@ -810,12 +826,17 @@ export class CopilotSdkAdapter extends EngineAdapter {
   }
 
   async setModel(sessionId: string, modelId: string): Promise<void> {
+    const previousModelId = this.currentModelId;
     this.currentModelId = modelId;
     const session = this.activeSessions.get(sessionId);
     if (session) {
-      try {
-        await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, modelId));
-      } catch (err) {}
+      if (this.shouldReopenForConfigDiscovery(previousModelId, modelId)) {
+        await this.reopenActiveSession(sessionId);
+      } else {
+        try {
+          await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, modelId));
+        } catch (err) {}
+      }
     }
   }
 
@@ -842,9 +863,13 @@ export class CopilotSdkAdapter extends EngineAdapter {
     }
     const session = this.activeSessions.get(sessionId);
     if (session && this.currentModelId) {
-      try {
-        await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, this.currentModelId));
-      } catch (err) {}
+      if (this.isGeminiModel(this.currentModelId)) {
+        await this.reopenActiveSession(sessionId);
+      } else {
+        try {
+          await session.rpc.model.switchTo(this.buildModelSwitchConfig(sessionId, this.currentModelId));
+        } catch (err) {}
+      }
     }
   }
 
@@ -868,6 +893,23 @@ export class CopilotSdkAdapter extends EngineAdapter {
   private getSdkReasoningEffort(sessionId: string): CopilotReasoningEffort | undefined {
     const effort = this.sessionReasoningEfforts.get(sessionId);
     return effort ? this.toSdkReasoningEffort(effort) : undefined;
+  }
+
+  private isGeminiModel(modelId: string | null | undefined): boolean {
+    return typeof modelId === "string" && modelId.startsWith("gemini-");
+  }
+
+  private shouldEnableConfigDiscovery(modelId: string | null | undefined): boolean {
+    // Gemini requests fail in Copilot SDK 1.0 when config discovery expands
+    // project instructions/skills before slash-command agent prompts.
+    return !this.isGeminiModel(modelId);
+  }
+
+  private shouldReopenForConfigDiscovery(
+    previousModelId: string | null | undefined,
+    nextModelId: string | null | undefined,
+  ): boolean {
+    return this.shouldEnableConfigDiscovery(previousModelId) !== this.shouldEnableConfigDiscovery(nextModelId);
   }
 
   async replyPermission(permissionId: string, reply: PermissionReply, _sessionId?: string): Promise<void> {
@@ -1259,6 +1301,19 @@ export class CopilotSdkAdapter extends EngineAdapter {
     if (!this.client || this.status !== "running") throw new Error("Copilot SDK adapter is not running");
   }
 
+  private async reopenActiveSession(sessionId: string, directory?: string): Promise<CopilotSession> {
+    const existing = this.activeSessions.get(sessionId);
+    if (existing) {
+      this.activeSessions.delete(sessionId);
+      try {
+        await existing.disconnect();
+      } catch (err) {
+        copilotLog.debug(`[Copilot][${sessionId}] disconnect before session reconfigure failed:`, err);
+      }
+    }
+    return this.ensureActiveSession(sessionId, directory);
+  }
+
   private async ensureActiveSession(sessionId: string, directory?: string): Promise<CopilotSession> {
     const existing = this.activeSessions.get(sessionId);
     if (existing) return existing;
@@ -1288,7 +1343,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
       onPermissionRequest: (req, ctx) => this.handlePermissionRequest(req, ctx),
       onUserInputRequest: (req, ctx) => this.handleUserInputRequest(req as any, ctx),
       enableSkills: true,
-      enableConfigDiscovery: true,
+      enableConfigDiscovery: this.shouldEnableConfigDiscovery(this.currentModelId),
     };
 
     copilotLog.info(`Resuming session ${sessionId}...`);
@@ -1312,7 +1367,7 @@ export class CopilotSdkAdapter extends EngineAdapter {
           onPermissionRequest: (req, ctx) => this.handlePermissionRequest(req, ctx),
           onUserInputRequest: (req, ctx) => this.handleUserInputRequest(req as any, ctx),
           enableSkills: true,
-          enableConfigDiscovery: true,
+          enableConfigDiscovery: this.shouldEnableConfigDiscovery(this.currentModelId),
         };
         const newSession = await this.client!.createSession(newConfig);
         this.subscribeToSessionEvents(newSession, sessionId);

--- a/electron/main/gateway/engine-manager.ts
+++ b/electron/main/gateway/engine-manager.ts
@@ -984,6 +984,23 @@ export class EngineManager extends EventEmitter {
     };
   }
 
+  private buildInitialEngineMeta(
+    meta: Record<string, unknown> | undefined,
+    options: {
+      mode?: string;
+      modelId?: string;
+      reasoningEffort?: ReasoningEffort | null;
+      serviceTier?: CodexServiceTier | null;
+    },
+  ): Record<string, unknown> | undefined {
+    const initialMeta: Record<string, unknown> = { ...(meta ?? {}) };
+    if (options.mode) initialMeta.codemuxInitialMode = options.mode;
+    if (options.modelId) initialMeta.codemuxInitialModelId = options.modelId;
+    if (options.reasoningEffort) initialMeta.codemuxInitialReasoningEffort = options.reasoningEffort;
+    if (options.serviceTier) initialMeta.codemuxInitialServiceTier = options.serviceTier;
+    return Object.keys(initialMeta).length > 0 ? initialMeta : undefined;
+  }
+
   private updateStoredSessionConfig(
     sessionId: string,
     patch: {
@@ -1029,13 +1046,17 @@ export class EngineManager extends EventEmitter {
       if (!conv) throw new Error(`Conversation not found: ${sessionId}`);
 
       const adapter = this.getAdapterForSession(sessionId);
+      const resolvedOptions = this.resolveSessionOptions(conv, options);
 
       // Lazy engine session creation: first sendMessage triggers adapter.createSession()
       // Also re-create if the adapter lost track of the session (e.g. after app restart,
       // the persisted engineSessionId refers to a cs_ ID that only existed in runtime memory).
       let engineSessionId = conv.engineSessionId;
       if (!engineSessionId || !adapter.hasSession(engineSessionId)) {
-        const engineSession = await adapter.createSession(conv.directory, conv.engineMeta);
+        const engineSession = await adapter.createSession(
+          conv.directory,
+          this.buildInitialEngineMeta(conv.engineMeta, resolvedOptions),
+        );
         engineSessionId = engineSession.id;
         conversationStore.setEngineSession(sessionId, engineSessionId, engineSession.engineMeta);
       }
@@ -1047,7 +1068,6 @@ export class EngineManager extends EventEmitter {
       // (Some adapters like OpenCode don't emit user message events)
       await this.persistUserMessage(sessionId, content, trackQueuedTiming);
 
-      const resolvedOptions = this.resolveSessionOptions(conv, options);
       const result = await adapter.sendMessage(engineSessionId, content, {
         ...resolvedOptions,
         directory: conv.directory,
@@ -1163,11 +1183,15 @@ export class EngineManager extends EventEmitter {
       if (!conv) throw new Error(`Conversation not found: ${sessionId}`);
 
       const adapter = this.getAdapterForSession(sessionId);
+      const resolvedOptions = this.resolveSessionOptions(conv, options);
 
       // Lazy engine session creation (same pattern as sendMessage)
       let engineSessionId = conv.engineSessionId;
       if (!engineSessionId || !adapter.hasSession(engineSessionId)) {
-        const engineSession = await adapter.createSession(conv.directory, conv.engineMeta);
+        const engineSession = await adapter.createSession(
+          conv.directory,
+          this.buildInitialEngineMeta(conv.engineMeta, resolvedOptions),
+        );
         engineSessionId = engineSession.id;
         conversationStore.setEngineSession(sessionId, engineSessionId, engineSession.engineMeta);
       }
@@ -1176,8 +1200,6 @@ export class EngineManager extends EventEmitter {
       // Persist user command message
       const commandText = `/${commandName}${args ? ` ${args}` : ""}`;
       await this.persistUserMessage(sessionId, [{ type: "text", text: commandText }], trackQueuedTiming);
-
-      const resolvedOptions = this.resolveSessionOptions(conv, options);
 
       const result = await adapter.invokeCommand(
         engineSessionId,

--- a/tests/unit/electron/engines/copilot/index.test.ts
+++ b/tests/unit/electron/engines/copilot/index.test.ts
@@ -432,6 +432,20 @@ describe("CopilotSdkAdapter", () => {
       );
     });
 
+    it("disables config discovery when the initial model is Gemini", async () => {
+      await adapter.createSession("/repo", {
+        codemuxInitialModelId: "gemini-3.1-pro-preview",
+      });
+
+      expect(mockClientInstance.createSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          model: "gemini-3.1-pro-preview",
+          enableSkills: true,
+          enableConfigDiscovery: false,
+        }),
+      );
+    });
+
     it("subscribes to session events after creation", async () => {
       const newSess = { ...mockSessionBase, sessionId: "s-new", on: vi.fn(() => vi.fn()) };
       mockClientInstance.createSession.mockResolvedValueOnce(newSess);
@@ -732,6 +746,34 @@ describe("CopilotSdkAdapter", () => {
       expect(sess.rpc.model.switchTo).toHaveBeenCalledWith(
         expect.objectContaining({ modelId: "new-model" }),
       );
+    });
+
+    it("reopens the session when switching across the Gemini config discovery boundary", async () => {
+      (adapter as any).currentModelId = "gpt-4o";
+      const resumed = makeMockSession("s1");
+      mockClientInstance.resumeSession.mockResolvedValueOnce(resumed);
+
+      const sendPromise = adapter.sendMessage(
+        "s1",
+        [{ type: "text", text: "hi" }],
+        { modelId: "gemini-3.1-pro-preview", reasoningEffort: "high" },
+      );
+      await flushMicrotasks();
+      (adapter as any).handleSessionIdle("s1");
+      await sendPromise;
+
+      expect(sess.disconnect).toHaveBeenCalledTimes(1);
+      expect(sess.rpc.model.switchTo).not.toHaveBeenCalled();
+      expect(mockClientInstance.resumeSession).toHaveBeenCalledTimes(1);
+      expect(mockClientInstance.resumeSession).toHaveBeenCalledWith(
+        "s1",
+        expect.objectContaining({
+          model: "gemini-3.1-pro-preview",
+          reasoningEffort: "high",
+          enableConfigDiscovery: false,
+        }),
+      );
+      expect(resumed.send).toHaveBeenCalledWith(expect.objectContaining({ prompt: "hi" }));
     });
 
     it("sets the session mode via rpc when mode changes", async () => {
@@ -2033,6 +2075,25 @@ describe("CopilotSdkAdapter", () => {
       await adapter.setReasoningEffort("s1", "medium");
 
       expect(sess.rpc.model.switchTo).not.toHaveBeenCalled();
+    });
+
+    it("reopens Gemini sessions when reasoning effort changes", async () => {
+      (adapter as any).currentModelId = "gemini-3.1-pro-preview";
+      const sess = makeMockSession("s1");
+      (adapter as any).activeSessions.set("s1", sess);
+
+      await adapter.setReasoningEffort("s1", "max");
+
+      expect(sess.disconnect).toHaveBeenCalledTimes(1);
+      expect(sess.rpc.model.switchTo).not.toHaveBeenCalled();
+      expect(mockClientInstance.resumeSession).toHaveBeenCalledWith(
+        "s1",
+        expect.objectContaining({
+          model: "gemini-3.1-pro-preview",
+          reasoningEffort: "xhigh",
+          enableConfigDiscovery: false,
+        }),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- pass the resolved model/reasoning options into lazy Copilot SDK session creation
- disable Copilot SDK config discovery for Gemini sessions to avoid `/review` agent-prompt CAPI 400s
- reopen/resume active SDK sessions when switching across the Gemini/non-Gemini config-discovery boundary, including mid-session model switches before `/review`
- cover initial Gemini sessions, mid-session Gemini switches, and Gemini reasoning-effort changes in unit tests

## Bug detail
The CodeMux model picker can return a valid Copilot model such as `gemini-3.1-pro-preview`, but the adapter previously did not apply that selection early enough for lazily-created sessions. On the first `message.send` or `command.invoke`, CodeMux created the Copilot SDK session with the default/previous model and only then called `session.rpc.model.switchTo()` with the picker model.

That was one trigger for the observed failure in `conv_019f02682e7a0000f54998089b`: `/review https://github.com/realDuang/codemux/pull/160` expands to an agent prompt asking the model to call the `task` tool with `agent_type: "code-review"`; after a default-session -> Gemini switch, the follow-up request returned `CAPIError: 400 Bad Request`.

Follow-up testing found the deeper Gemini-specific issue: Copilot SDK sessions with `enableConfigDiscovery: true` can also fail on the same `/review` agent-prompt path even when Gemini is selected at session creation. Basic Gemini sends still work, which is why this looked like a picker/model-validity issue rather than an SDK session-configuration issue.

The fix now initializes lazy sessions with the selected model/reasoning effort, disables config discovery for Gemini sessions, and reopens/resumes the SDK session when switching between Gemini and non-Gemini models so the immutable config-discovery setting matches the active model. This specifically covers the case of using one model in a session, switching to Gemini in the picker, then sending `/review`.

## CI note
The earlier macOS unit-test failure was an environment/install issue (`Electron failed to install correctly...`) rather than this code path; rerunning the failed job passed.

## Validation
- `bun run test:unit tests\\unit\\electron\\engines\\copilot\\index.test.ts`
- `npm run typecheck`
- `npm run lint -- --quiet`
- `bun run test:unit`