### PR TITLE
fix(homebrew): use symbol form for depends_on macos to silence deprecation warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -395,7 +395,7 @@ jobs:
             end
 
             auto_updates true
-            depends_on macos: \">= :ventura\"
+            depends_on macos: :ventura
 
             app \"CodeMux.app\"
 

--- a/homebrew/codemux.rb
+++ b/homebrew/codemux.rb
@@ -21,7 +21,7 @@ cask "codemux" do
   end
 
   auto_updates true
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "CodeMux.app"
 


### PR DESCRIPTION
## Problem

Installing the CodeMux Homebrew cask emits a deprecation warning on recent Homebrew versions:

```
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :ventura` instead.
  .../Casks/codemux.rb:24
```

The cask used the deprecated **string comparison** form `depends_on macos: ">= :ventura"`.

## Fix

Switch to the **symbol form** `depends_on macos: :ventura`, which is the non-deprecated, preferred syntax. Per the [Homebrew Cask Cookbook](https://docs.brew.sh/Cask-Cookbook#depends_on-macos), `depends_on macos: :ventura` declares the **minimum compatible macOS release** — semantically identical to `">= :ventura"`.

Changed in **two** places so the fix is durable:

- `homebrew/codemux.rb` — the source cask
- `.github/workflows/release.yml` — the release job that regenerates the cask on every release (otherwise the next release would reintroduce the old syntax)

> Note: The live tap repo `realDuang/homebrew-codemux` was already patched directly (commit `d8fcd7c`) so installed users stop seeing the warning immediately. This PR keeps the source-of-truth in sync so future releases stay warning-free.

## Verification

Reproduced via a local tap and confirmed:

- **Before** (`">= :ventura"`) → emits the exact reported warning
- **After** (`:ventura`) → no warning
- `ruby -c` syntax OK; the `depends_on macos:` offense no longer appears in `brew style`
- Simulated the release workflow's Python cask generation — output is valid Ruby
